### PR TITLE
issue#5: LLVM error when using both OpImageSampleDref* and OpImageSample* on the same image

### DIFF
--- a/icd/api/llpc/translator/SPIRVUtil.cpp
+++ b/icd/api/llpc/translator/SPIRVUtil.cpp
@@ -1263,7 +1263,6 @@ getSPIRVImageTypePostfixes(StringRef SampledType,
   raw_string_ostream OS(S);
   OS << SampledType << kSPIRVTypeName::PostfixDelim
      << Desc.Dim << kSPIRVTypeName::PostfixDelim
-     << Desc.Depth << kSPIRVTypeName::PostfixDelim
      << Desc.Arrayed << kSPIRVTypeName::PostfixDelim
      << Desc.MS << kSPIRVTypeName::PostfixDelim
      << Desc.Sampled << kSPIRVTypeName::PostfixDelim


### PR DESCRIPTION
root cause: Per SPIRV spec, Depth is not a property of type, we should not include it in the type's mangle name.
