### PR TITLE
issue#4: Mismatch of OpName on entry point and OpEntryPoint name causes crash

### DIFF
--- a/icd/api/llpc/translator/SPIRVWriter.cpp
+++ b/icd/api/llpc/translator/SPIRVWriter.cpp
@@ -655,8 +655,12 @@ LLVMToSPIRV::transFunctionDecl(Function *F) {
   BF->setFunctionControlMask(transFunctionControlMask(F));
   if (F->hasName())
     BM->setName(BF, F->getName());
-  if (oclIsKernel(F))
-    BM->addEntryPoint(ExecutionModelKernel, BF->getId());
+  if (oclIsKernel(F)) {
+    SPIRVEntryPoint* EntryPoint =
+      new SPIRVEntryPoint(BM,ExecutionModelKernel, BF->getId(), F->getName());
+    BM->add(EntryPoint);
+    BM->addEntryPoint(EntryPoint);
+  }
   else if (F->getLinkage() != GlobalValue::InternalLinkage)
     BF->setLinkageType(transLinkageType(F));
   auto Attrs = F->getAttributes();

--- a/icd/api/llpc/translator/libSPIRV/SPIRVEntry.cpp
+++ b/icd/api/llpc/translator/libSPIRV/SPIRVEntry.cpp
@@ -467,7 +467,7 @@ SPIRVEntryPoint::decode(std::istream &I) {
   InOuts.resize(NumInOuts);
   getDecoder(I) >> InOuts;
   Module->setName(getOrCreateTarget(), Name);
-  Module->addEntryPoint(ExecModel, Target);
+  Module->addEntryPoint(this);
 }
 
 void

--- a/icd/api/llpc/translator/libSPIRV/SPIRVEntry.h
+++ b/icd/api/llpc/translator/libSPIRV/SPIRVEntry.h
@@ -439,6 +439,8 @@ public:
   SPIRVEntryPoint(SPIRVModule *TheModule, SPIRVExecutionModelKind,
       SPIRVId TheId, const std::string &TheName);
   SPIRVEntryPoint():ExecModel(ExecutionModelKernel){}
+  SPIRVExecutionModelKind getExecModel()const { return ExecModel; }
+  std::string getName()const { return Name; }
   _SPIRV_DCL_ENCDEC
 protected:
   SPIRVExecutionModelKind ExecModel;

--- a/icd/api/llpc/translator/libSPIRV/SPIRVModule.h
+++ b/icd/api/llpc/translator/libSPIRV/SPIRVModule.h
@@ -134,8 +134,9 @@ public:
   virtual std::vector<SPIRVType *> getValueTypes(const std::vector<SPIRVId>&)
       const = 0;
   virtual SPIRVConstant* getLiteralAsConstant(unsigned Literal) = 0;
-  virtual bool isEntryPoint(SPIRVExecutionModelKind, SPIRVId) const = 0;
-  virtual bool isEntryPoint(SPIRVId, SPIRVExecutionModelKind * = nullptr) const = 0;
+  virtual SPIRVEntryPoint *getEntryPoint(SPIRVId) const = 0;
+  virtual SPIRVEntryPoint *getEntryPoint(
+    SPIRVExecutionModelKind, const char *) const = 0;
 
   virtual unsigned short getGeneratorId() const = 0;
   virtual unsigned short getGeneratorVer() const = 0;
@@ -186,7 +187,7 @@ public:
       SPIRVDecorationGroup *Group, const std::vector<SPIRVEntry *> &Targets) = 0;
   virtual SPIRVGroupDecorateGeneric *addGroupDecorateGeneric(
       SPIRVGroupDecorateGeneric *GDec) = 0;
-  virtual void addEntryPoint(SPIRVExecutionModelKind, SPIRVId) = 0;
+  virtual void addEntryPoint(SPIRVEntryPoint *EntryPoint) = 0;
   virtual SPIRVForward *addForward(SPIRVType *Ty) = 0;
   virtual SPIRVForward *addForward(SPIRVId, SPIRVType *Ty) = 0;
   virtual SPIRVFunction *addFunction(SPIRVFunction *) = 0;


### PR DESCRIPTION
Port internal fix to dev branch

Root cause: The name of entry point may be different with the function name. and we should not use the function name in translator, it is debug info.

Solution: per SPIR-V spec, entry point name + exec model are unique in shader module, and translate need query entry point via function Id frequently, it is not easy support fast search with a set/map.
consider there are not a lot of entry point in a shader module, a simple vector is used to simplify the implementation.

Change:
1. Replace EntryPointSet and EntryPointVec with EntryPointVec in SPIRVModuleImpl
2. Add getExecModel and getName in SPIRVEntryPoint
3. Replace isEntryPoint with getEntryPoint, and support query entry point via function Id or entry point name + exec model.
4. Modify related functions to match the change in interface and class member.