### PR TITLE
Extend range of formats for testing on KHR_wayland_surface

### DIFF
--- a/icd/api/vk_dispatch.cpp
+++ b/icd/api/vk_dispatch.cpp
@@ -109,7 +109,7 @@ bool DispatchTable::CheckAPIVersion(uint32_t apiVersion)
         return m_pDevice->VkInstance()->GetAPIVersion() >= apiVersion;
 
     default:
-        VK_ASSERT("Unexpected dispatch table type");
+        VK_ASSERT(!"Unexpected dispatch table type");
         return false;
     }
 }
@@ -133,7 +133,7 @@ bool DispatchTable::CheckInstanceExtension(InstanceExtensions::ExtensionId id)
         return m_pDevice->VkInstance()->IsExtensionEnabled(id);
 
     default:
-        VK_ASSERT("Unexpected dispatch table type");
+        VK_ASSERT(!"Unexpected dispatch table type");
         return false;
     }
 }
@@ -157,7 +157,7 @@ bool DispatchTable::CheckDeviceExtension(DeviceExtensions::ExtensionId id)
         return m_pDevice->IsExtensionEnabled(id);
 
     default:
-        VK_ASSERT("Unexpected dispatch table type");
+        VK_ASSERT(!"Unexpected dispatch table type");
         return false;
     }
 }

--- a/icd/api/vk_physical_device.cpp
+++ b/icd/api/vk_physical_device.cpp
@@ -2370,9 +2370,14 @@ VkResult PhysicalDevice::GetSurfaceFormats(
         // Windowed Presents
 
         // The w/a here will be removed once more presentable format is supported on base driver side.
+
+        //These are the formats currently working with KHR_wayland_surface
+        // NB THEY ARE NOT FULLY TESTED ON X11 AND SOME MIGHT NEED TO BE DISABLED FOR NOW
         const VkSurfaceFormatKHR formatList[] = {
-            { VK_FORMAT_B8G8R8A8_UNORM, VK_COLORSPACE_SRGB_NONLINEAR_KHR },
-            { VK_FORMAT_B8G8R8A8_SRGB,  VK_COLORSPACE_SRGB_NONLINEAR_KHR } };
+            { VK_FORMAT_B8G8R8A8_UNORM,           VK_COLORSPACE_SRGB_NONLINEAR_KHR },
+            { VK_FORMAT_B8G8R8A8_SRGB,            VK_COLORSPACE_SRGB_NONLINEAR_KHR },
+            { VK_FORMAT_A2R10G10B10_UNORM_PACK32, VK_COLORSPACE_SRGB_NONLINEAR_KHR },
+            { VK_FORMAT_R5G6B5_UNORM_PACK16,      VK_COLORSPACE_SRGB_NONLINEAR_KHR }, };
         const uint32_t formatCount = sizeof(formatList) / sizeof(formatList[0]);
 
         if (pSurfaceFormats == nullptr)


### PR DESCRIPTION
* Add formats to range for testing on wayland (only)

- VK_FORMAT_A2R10G10B10_UNORM_PACK32
- VK_FORMAT_R5G6B5_UNORM_PACK16

! NB These formats cause problems on other platforms

* Fix some bad asserts in vk_dispatch.cpp