### PR TITLE
Ignore pInheritanceInfo for primary command buffers.

### DIFF
--- a/icd/api/vk_cmdbuffer.cpp
+++ b/icd/api/vk_cmdbuffer.cpp
@@ -1077,7 +1077,7 @@ VkResult CmdBuffer::Begin(
                 break;
             }
 
-            if (pInfo->pInheritanceInfo != nullptr)
+            if (m_is2ndLvl && pInfo->pInheritanceInfo != nullptr)
             {
                 pRenderPass = RenderPass::ObjectFromHandle(pInfo->pInheritanceInfo->renderPass);
                 pFramebuffer = Framebuffer::ObjectFromHandle(pInfo->pInheritanceInfo->framebuffer);


### PR DESCRIPTION
The Vulkan spec says:
> pInheritanceInfo is a pointer to a VkCommandBufferInheritanceInfo structure, which is used if commandBuffer is a secondary command buffer. If this is a primary command buffer, then this value is ignored.

Fixes potential crashes in the driver.