### PR TITLE
Fix ASAN error

### DIFF
--- a/icd/api/llpc/patch/llpcPatchEntryPointMutate.cpp
+++ b/icd/api/llpc/patch/llpcPatchEntryPointMutate.cpp
@@ -960,8 +960,13 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
             }
         }
     }
-    const auto enableMultiView = (static_cast<const GraphicsPipelineBuildInfo*>(
-                            m_pContext->GetPipelineBuildInfo()))->iaState.enableMultiView;
+    bool enableMultiView = false;
+    if (m_shaderStage != ShaderStageCompute)
+    {
+        enableMultiView = (static_cast<const GraphicsPipelineBuildInfo*>(
+            m_pContext->GetPipelineBuildInfo()))
+            ->iaState.enableMultiView;
+    }
 
     switch (m_shaderStage)
     {


### PR DESCRIPTION
Unmodified code triggers an address sanitizer error on my machine.

Accessing the GraphicsPipelineBuildInfo while compiling a compute pipeline accesses out of bounds memory which triggers the error. My fix changes the access to graphics specific memory to only occur when compiling graphics pipelines.