### PR TITLE
Add disableLicm tuning option

### DIFF
--- a/icd/api/app_shader_optimizer.cpp
+++ b/icd/api/app_shader_optimizer.cpp
@@ -142,6 +142,12 @@ void ShaderOptimizer::ApplyProfileToShaderCreateInfo(
                     options.pOptions->enableLoadScalarizer = true;
                 }
 #endif
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
+                if (shaderCreate.tuningOptions.disableLicm)
+                {
+                    options.pOptions->disableLicm = true;
+                }
+#endif
 
                 if (shaderCreate.apply.waveSize)
                 {
@@ -1535,6 +1541,7 @@ static bool ParseJsonProfileActionShader(
         "nggEnableSmallPrimFilter",
         "enableSubvector",
         "enableSubvectorSharedVgprs",
+        "disableLicm"
     };
 
     success &= CheckValidKeys(pJson, VK_ARRAY_SIZE(ValidKeys), ValidKeys);
@@ -1751,6 +1758,13 @@ static bool ParseJsonProfileActionShader(
         if (pItem->integerValue != 0)
         {
             pActions->shaderCreate.tuningOptions.reconfigWorkgroupLayout = true;
+        }
+    }
+    if ((pItem = utils::JsonGetValue(pJson, "disableLicm")) != nullptr)
+    {
+        if (pItem->integerValue != 0)
+        {
+            pActions->shaderCreate.tuningOptions.disableLicm = true;
         }
     }
 

--- a/icd/api/include/app_shader_optimizer.h
+++ b/icd/api/include/app_shader_optimizer.h
@@ -115,6 +115,7 @@ struct ShaderTuningOptions
     uint32_t useSiScheduler;
     uint32_t reconfigWorkgroupLayout;
     bool enableLoadScalarizer;
+    uint32_t disableLicm;
 };
 
 struct ShaderProfileAction


### PR DESCRIPTION
Added the "disableLicm" tuning option, which passes metadata to the
LLVM back-end to suppress the LICM pass.

Updated LLPC client version to 35 with the addition of the disableLicm
option.