### PR TITLE
Fix builds with GFX10 support disabled.

### DIFF
--- a/icd/api/app_shader_optimizer.cpp
+++ b/icd/api/app_shader_optimizer.cpp
@@ -143,6 +143,7 @@ void ShaderOptimizer::ApplyProfileToShaderCreateInfo(
                 }
 #endif
 
+#if LLPC_BUILD_GFX10
                 if (shaderCreate.apply.waveSize)
                 {
                     options.pOptions->waveSize = shaderCreate.tuningOptions.waveSize;
@@ -198,8 +199,8 @@ void ShaderOptimizer::ApplyProfileToShaderCreateInfo(
                 {
                     options.pNggState->enableSmallPrimFilter = true;
                 }
+#endif
             }
-
         }
     }
 }

--- a/icd/api/include/app_shader_optimizer.h
+++ b/icd/api/include/app_shader_optimizer.h
@@ -241,7 +241,9 @@ struct PipelineShaderOptionsPtr
 {
     Llpc::PipelineOptions*       pPipelineOptions;
     Llpc::PipelineShaderOptions* pOptions;
+#if LLPC_BUILD_GFX10
     Llpc::NggState*              pNggState;
+#endif
 };
 
 // =====================================================================================================================

--- a/icd/api/include/pipeline_compiler.h
+++ b/icd/api/include/pipeline_compiler.h
@@ -166,7 +166,9 @@ private:
         Llpc::PipelineOptions*       pPipelineOptions,
         Llpc::PipelineShaderInfo*    pShaderInfo,
         PipelineOptimizerKey*        pProfileKey
+#if LLPC_BUILD_GFX10
         , Llpc::NggState*            pNggState
+#endif
     );
 
     void GetElfCacheMetricString(char* pOutStr, size_t outStrSize);

--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -649,7 +649,9 @@ VkResult PipelineCompiler::CreateGraphicsPipelineBinary(
         hash.Update(pCreateInfo->pipelineInfo.gs.options);
         hash.Update(pCreateInfo->pipelineInfo.fs.options);
         hash.Update(pCreateInfo->pipelineInfo.options);
+#if LLPC_BUILD_GFX10
         hash.Update(pCreateInfo->pipelineInfo.nggState);
+#endif
         hash.Update(pCreateInfo->flags);
         hash.Update(pCreateInfo->dbFormat);
         hash.Update(pCreateInfo->pipelineProfileKey);
@@ -1228,6 +1230,7 @@ VkResult PipelineCompiler::ConvertGraphicsPipelineInfo(
         }
     }
 
+#if LLPC_BUILD_GFX10
     if (m_gfxIp.major >= 10)
     {
         const bool                 hasGs        = pStageInfos[ShaderStageGeometry] != nullptr;
@@ -1265,6 +1268,7 @@ VkResult PipelineCompiler::ConvertGraphicsPipelineInfo(
         pCreateInfo->pipelineInfo.nggState.primsPerSubgroup           = settings.nggPrimsPerSubgroup;
         pCreateInfo->pipelineInfo.nggState.vertsPerSubgroup           = settings.nggVertsPerSubgroup;
     }
+#endif
 
     ApplyPipelineOptions(pDevice, flags, &pCreateInfo->pipelineInfo.options);
 
@@ -1369,7 +1373,9 @@ VkResult PipelineCompiler::ConvertGraphicsPipelineInfo(
                             &pCreateInfo->pipelineInfo.options,
                             pShaderInfo,
                             &pCreateInfo->pipelineProfileKey
+#if LLPC_BUILD_GFX10
                             , &pCreateInfo->pipelineInfo.nggState
+#endif
                             );
     }
 
@@ -1554,7 +1560,9 @@ VkResult PipelineCompiler::ConvertComputePipelineInfo(
                         nullptr,
                         &pCreateInfo->pipelineInfo.cs,
                         &pCreateInfo->pipelineProfileKey
+#if LLPC_BUILD_GFX10
                       , nullptr
+#endif
                         );
 
     return result;
@@ -1567,6 +1575,7 @@ void PipelineCompiler::ApplyDefaultShaderOptions(
     Llpc::PipelineShaderOptions* pShaderOptions
     ) const
 {
+#if LLPC_BUILD_GFX10
     const RuntimeSettings& settings = m_pPhysicalDevice->GetRuntimeSettings();
 
     switch (stage)
@@ -1595,7 +1604,7 @@ void PipelineCompiler::ApplyDefaultShaderOptions(
 
     pShaderOptions->wgpMode       = ((settings.enableWgpMode & (1 << stage)) != 0);
     pShaderOptions->waveBreakSize = static_cast<Llpc::WaveBreakSize>(settings.waveBreakSize);
-
+#endif
 }
 
 // =====================================================================================================================
@@ -1607,14 +1616,18 @@ void PipelineCompiler::ApplyProfileOptions(
     Llpc::PipelineOptions*       pPipelineOptions,
     Llpc::PipelineShaderInfo*    pShaderInfo,
     PipelineOptimizerKey*        pProfileKey
+#if LLPC_BUILD_GFX10
     , Llpc::NggState*            pNggState
+#endif
     )
 {
     auto&    settings  = m_pPhysicalDevice->GetRuntimeSettings();
     PipelineShaderOptionsPtr options = {};
     options.pPipelineOptions = pPipelineOptions;
     options.pOptions     = &pShaderInfo->options;
+#if LLPC_BUILD_GFX10
     options.pNggState    = pNggState;
+#endif
 
     auto& shaderKey = pProfileKey->shaders[stage];
     if (settings.pipelineUseShaderHashAsProfileHash)

--- a/icd/api/vk_device.cpp
+++ b/icd/api/vk_device.cpp
@@ -1186,6 +1186,7 @@ VkResult Device::Initialize(
             break;
         }
         case AppProfile::WolfensteinII:
+#if LLPC_BUILD_GFX10
             // This application optimization layer is currently GFX10-specific
             if (deviceProps.gfxLevel >= Pal::GfxIpLevel::GfxIp10_1)
             {
@@ -1200,6 +1201,7 @@ VkResult Device::Initialize(
                     result = VK_ERROR_OUT_OF_HOST_MEMORY;
                 }
             }
+#endif
             break;
         default:
             break;


### PR DESCRIPTION
This adds extra guards around code that is only valid when building with
GFX10 enabled.

Tested with GFX10 support disabled and GFX10 support enabled.

Note that this requires changes in the other drivers as well.