### PR TITLE
Tuning option for loop unroll threshold

### DIFF
--- a/icd/api/app_shader_optimizer.cpp
+++ b/icd/api/app_shader_optimizer.cpp
@@ -146,6 +146,10 @@ void ShaderOptimizer::ApplyProfileToShaderCreateInfo(
                 {
                     options.pOptions->forceLoopUnrollCount = shaderCreate.tuningOptions.forceLoopUnrollCount;
                 }
+                if (shaderCreate.tuningOptions.unrollThreshold != 0)
+                {
+                    options.pOptions->unrollThreshold = shaderCreate.tuningOptions.unrollThreshold;
+                }
 
                 if (shaderCreate.apply.waveSize)
                 {
@@ -1579,6 +1583,7 @@ static bool ParseJsonProfileActionShader(
         "reconfigWorkgroupLayout",
         "forceLoopUnrollCount",
         "enableLoadScalarizer",
+        "unrollThreshold",
         "waveSize",
         "wgpMode",
         "waveBreakSize",
@@ -1822,6 +1827,13 @@ static bool ParseJsonProfileActionShader(
         if (pItem->integerValue != 0)
         {
             pActions->shaderCreate.tuningOptions.enableLoadScalarizer = true;
+        }
+    }
+    if ((pItem = utils::JsonGetValue(pJson, "unrollThreshold")) != nullptr)
+    {
+        if (pItem->integerValue != 0)
+        {
+            pActions->shaderCreate.tuningOptions.unrollThreshold = static_cast<uint32_t>(pItem->integerValue);
         }
     }
 

--- a/icd/api/include/app_shader_optimizer.h
+++ b/icd/api/include/app_shader_optimizer.h
@@ -116,6 +116,7 @@ struct ShaderTuningOptions
     uint32_t reconfigWorkgroupLayout;
     uint32_t forceLoopUnrollCount;
     bool enableLoadScalarizer;
+    uint32_t unrollThreshold;
 };
 
 struct ShaderProfileAction


### PR DESCRIPTION
Add a shader tuning option "unrollThreshold" to allow the default loop unroll
threshold used by LLVM to be initialised to the specified value.
If a non-zero unrollThreshold is specified then it is passed to LLVM by use
of an attribute "amdgpu-unroll-threshold" that is attached to each function.
The unroll threshold used for each loop is then initialised to the specified
value before the target specific heuristics are applied, which may increase it.