### PR TITLE
api: Use truncateCoords for Vulkan samplers

### DIFF
--- a/icd/api/vk_sampler.cpp
+++ b/icd/api/vk_sampler.cpp
@@ -170,6 +170,9 @@ VkResult Sampler::Create(
             samplerInfo.flags.unnormalizedCoords       = (pSamplerInfo->unnormalizedCoordinates == VK_TRUE) ? 1 : 0;
             samplerInfo.flags.prtBlendZeroMode         = 0;
             samplerInfo.flags.seamlessCubeMapFiltering = 1;
+            samplerInfo.flags.truncateCoords           = (pSamplerInfo->magFilter == VK_FILTER_NEAREST &&
+                                                          pSamplerInfo->minFilter == VK_FILTER_NEAREST)
+                                                          ? 1 : 0;
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT:
             samplerInfo.filterMode = VkToPalTexFilterMode(pVkSamplerReductionModeCreateInfoEXT->reductionMode);


### PR DESCRIPTION
The default behaviour (0) is: "round-nearest-even to n.6 and drop fraction when point sampling" whereas the Vulkan spec simply wants us to floor it (1) "truncate when point sampling".

See 15.6.1 in the Vulkan spec.
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#textures-normalized-operations

The Direct3D spec also mandates this (https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#7.18.7%20Point%20Sample%20Addressing)

This fixes some point-sampling texture precision issues in some Direct3D 9 titles such as Guild Wars 2 and htoL#NiQ: The Firefly Diary that are not present on other vendors.

https://github.com/Joshua-Ashton/d9vk/issues/450
https://github.com/doitsujin/dxvk/issues/1433