### PR TITLE
Prepare for lgc directory move

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,12 @@ set(LLPC_BUILD_LIT ${XGL_BUILD_LIT} CACHE BOOL "${PROJECT_NAME} override." FORCE
 set(LLPC_BUILD_GFX10 ${XGL_BUILD_GFX10} CACHE BOOL "${PROJECT_NAME} override." FORCE)
 set(LLPC_BUILD_NAVI14 ${XGL_BUILD_NAVI14} CACHE BOOL "${PROJECT_NAME} override." FORCE)
 if(ICD_BUILD_LLPC)
+    # Add LGC as an LLVM external project, but only if its CMakeLists.txt exists.
+    if(EXISTS "${XGL_LLPC_PATH}/../lgc/CMakeLists.txt")
+        set(LLVM_EXTERNAL_PROJECTS lgc)
+        set(LLVM_EXTERNAL_LGC_SOURCE_DIR ${XGL_LLPC_PATH}/../lgc)
+    endif()
+    # Set other LLVM settings.
     set(LLVM_ENABLE_ASSERTIONS ${CMAKE_BUILD_TYPE_DEBUG} CACHE BOOL Force)
     set(LLVM_TARGETS_TO_BUILD AMDGPU CACHE STRING Force)
     set(LLVM_BUILD_TESTS OFF CACHE BOOL Force)

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -376,6 +376,10 @@ target_sources(xgl PRIVATE
 
 ### XGL LLVM ####
 if(ICD_BUILD_LLPC)
+    # Add LGC as a dependency, but only if its CMakeLists.txt exists.
+    if(EXISTS "${XGL_LLPC_PATH}/../lgc/CMakeLists.txt")
+        target_link_libraries(xgl PRIVATE LLVMlgc)
+    endif()
     target_link_libraries(xgl PRIVATE llpc dl stdc++)
     llvm_map_components_to_libnames(llvm_libs amdgpucodegen amdgpuinfo amdgpuasmparser amdgpudisassembler LTO ipo analysis bitreader bitwriter codegen irreader linker mc passes support target transformutils coroutines)
     target_link_libraries(xgl PRIVATE ${llvm_libs})


### PR DESCRIPTION
LGC (the middle-end of LLPC) is about to move to its own directory
within the llpc repository, and be built as a separate library. This
commit prepares for that by making xgl depend on liblgc, if the move has
happened.

Change-Id: Ifd54448640ba9c1dd24c2bfd58721c9e52544233