### PR TITLE
Handle null pipelines in SQTT

### DIFF
--- a/icd/api/sqtt/sqtt_layer.cpp
+++ b/icd/api/sqtt/sqtt_layer.cpp
@@ -2028,8 +2028,11 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyPipeline(
 #if ICD_GPUOPEN_DEVMODE_BUILD
     if (pDevice->GetRuntimeSettings().devModeShaderIsaDbEnable && (pDevMgr != nullptr))
     {
-        Pipeline* pPipeline = Pipeline::ObjectFromHandle(pipeline);
-        pDevMgr->PipelineDestroyed(pDevice, pPipeline);
+        if (VK_NULL_HANDLE != pipeline)
+        {
+            Pipeline* pPipeline = Pipeline::ObjectFromHandle(pipeline);
+            pDevMgr->PipelineDestroyed(pDevice, pPipeline);
+        }
     }
 #endif
 


### PR DESCRIPTION
We were seeing an issue with capturing RGP traces on a layer that was attempting to destroy null pipelines (Vulkan legal).