### PR TITLE
Fix error path of GetRandROutputDisplay()

### DIFF
--- a/icd/api/vk_physical_device.cpp
+++ b/icd/api/vk_physical_device.cpp
@@ -3824,7 +3824,7 @@ VkResult PhysicalDevice::GetRandROutputDisplay(
 
     if (pScreen == nullptr)
     {
-        VkResult result = VK_INCOMPLETE;
+        result = VK_INCOMPLETE;
     }
 
     return result;


### PR DESCRIPTION
If the function fails to find a pScreen for the RandR output, it is supposed to
return VK_INCOMPLETE. Indeed the error handling branch assigns
result = VK_INCOMPLETE, but to a new variable VkResult result, which is
only defined inside the scope of the error handling branch, instead of assigning
to the result variable inside the functions scope. Therefore the variable will go
out of scope at end of error handling and the function returns a wrong
VK_SUCCESS (and a pDisplay == NULL handle) in case of error.

Fix this trivially by assigning to the function scope result variable.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>