### PR TITLE
Fix broken vkGetPhysicalDeviceSurfaceFormatsKHR() for Linux direct display mode.

### DIFF
--- a/icd/api/vk_physical_device.cpp
+++ b/icd/api/vk_physical_device.cpp
@@ -3056,9 +3056,13 @@ VkResult PhysicalDevice::GetSurfaceFormats(
         uint32_t colorSpaceCount = 0;
         uint32_t numImgFormats = 0;
 
+        // Get supported color capabilities of screen:
+        Pal::Result palResult = pScreen->GetColorCapabilities(&palColorCaps);
+        VK_ASSERT(palResult == Pal::Result::Success);
+
         // Enumerate
         ColorSpaceHelper::GetSupportedFormats(palColorCaps.supportedColorSpaces, &colorSpaceCount, nullptr);
-        Pal::Result palResult = pScreen->GetFormats(&numImgFormats, nullptr);
+        palResult = pScreen->GetFormats(&numImgFormats, nullptr);
         VK_ASSERT(palResult == Pal::Result::Success);
         const size_t totalMem = (sizeof(Pal::SwizzledFormat)        * numImgFormats) +
                                 (sizeof(VkFormat)                   * numImgFormats) +


### PR DESCRIPTION
Both vkGetPhysicalDeviceSurfaceFormatsKHR() and
vkGetPhysicalDeviceSurfaceFormats2KHR() are totally broken for
Linux in direct display fullscreen exclusive mode.

They call PhysicalDevice::GetSurfaceFormats(), which after a recent
rewrite misses a call to pScreen->GetColorCapabilities(&palColorCaps);
This causes palColorCaps to be all-zero, so in a call to
ColorSpaceHelper::GetSupportedFormats(palColorCaps.supportedColorSpaces, ...)
palColorCaps.supportedColorSpaces is only TfUndefined. ColorSpaceHelper
therefore doesn't find any matching/supported colorspace + format combos
and returns 0 colorspaces -> 0 compatible formats, so
vkGetPhysicalDeviceSurfaceFormatsKHR() reports no surface formats in
fullscreen mode.

Fix this by adding the missing pScreen->GetColorCapabilities(&palColorCaps);
and Linux direct display mode works again.

Given that this code seems to be shared with Windows, and would affect
all display modes, including windowed/composited, i'm a bit baffled and
worried as to how this bug could have passed the test-suite?

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>