### PR TITLE
Verify physical device feature only on success

### DIFF
--- a/icd/api/vk_device.cpp
+++ b/icd/api/vk_device.cpp
@@ -785,7 +785,7 @@ VkResult Device::Create(
     }
 
     // If the pNext chain includes a VkPhysicalDeviceFeatures2 structure, then pEnabledFeatures must be NULL.
-    if (pCreateInfo->pEnabledFeatures != nullptr)
+    if ((vkResult == VK_SUCCESS) && (pCreateInfo->pEnabledFeatures != nullptr))
     {
         vkResult = VerifyRequestedPhysicalDeviceFeatures<VkPhysicalDeviceFeatures>(
             pPhysicalDevice,


### PR DESCRIPTION
The result of VerifyRequestedPhysicalDeviceFeatures could hide previous failures, only check if state is still success.