### PR TITLE
Add amdpalsettings options to enable relocatable shaders.

### DIFF
--- a/icd/api/include/vk_descriptor_set.h
+++ b/icd/api/include/vk_descriptor_set.h
@@ -111,7 +111,7 @@ public:
         uint32_t*       pUserData,
         const uint32_t* pDynamicOffsets,
         uint32_t        numDynamicDescriptors,
-        bool            robustBufferAccess);
+        bool            useCompactDescriptor);
 
 protected:
     DescriptorSet(uint32_t heapIndex);
@@ -196,14 +196,14 @@ void DescriptorSet<numPalDevices>::PatchedDynamicDataFromHandle(
     uint32_t*       pUserData,
     const uint32_t* pDynamicOffsets,
     uint32_t        numDynamicDescriptors,
-    bool            robustBufferAccess)
+    bool            useCompactDescriptor)
 {
     // This code expects 4 DW SRDs whose first 48 bits is the base address.
 
     DescriptorSet<numPalDevices>* pSet  = StateFromHandle(set);
     uint64_t* pDstQwords = reinterpret_cast<uint64_t*>(pUserData);
     uint64_t* pSrcQwords = pSet->DynamicDescriptorDataQw(deviceIdx);
-    const uint32_t dynDataNumQwords = robustBufferAccess ? 2 : 1;
+    const uint32_t dynDataNumQwords = useCompactDescriptor ? 1 : 2;
     for (uint32_t i = 0; i < numDynamicDescriptors; ++i)
     {
         const uint64_t baseAddressMask = 0x0000FFFFFFFFFFFFull;
@@ -217,7 +217,7 @@ void DescriptorSet<numPalDevices>::PatchedDynamicDataFromHandle(
 
         pDstQwords[i * dynDataNumQwords] = hiBits | baseAddress;
 
-        if (robustBufferAccess)
+        if (!useCompactDescriptor)
         {
             pDstQwords[i * dynDataNumQwords + 1] = pSrcQwords[i * dynDataNumQwords + 1];
         }

--- a/icd/api/include/vk_device.h
+++ b/icd/api/include/vk_device.h
@@ -580,6 +580,9 @@ public:
     VK_INLINE const bool IsDeviceCoherentMemoryEnabled() const
         { return m_deviceCoherentMemoryEnabled; }
 
+    VK_INLINE const bool UseCompactDynamicDescriptors() const
+        { return !GetRuntimeSettings().enableRelocatableShaders && !GetEnabledFeatures().robustBufferAccess;}
+
     Pal::IQueue* PerformSwCompositing(
         uint32_t         deviceIdx,
         uint32_t         presentationDeviceIdx,

--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -1499,6 +1499,7 @@ void PipelineCompiler::ApplyPipelineOptions(
     pOptions->shadowDescriptorTableUsage = Vkgc::ShadowDescriptorTableUsage::Enable;
     pOptions->shadowDescriptorTablePtrHigh =
           static_cast<uint32_t>(info.gpuMemoryProperties.shadowDescTableVaStart >> 32);
+    pOptions->enableRelocatableShaderElf = m_pPhysicalDevice->GetRuntimeSettings().enableRelocatableShaders;
 #endif
 }
 

--- a/icd/api/vk_cmdbuffer.cpp
+++ b/icd/api/vk_cmdbuffer.cpp
@@ -1622,7 +1622,7 @@ void CmdBuffer::ReleaseResources()
 }
 
 // =====================================================================================================================
-template <uint32_t numPalDevices, bool robustBufferAccess>
+template <uint32_t numPalDevices, bool useCompactDescriptor>
 void CmdBuffer::BindDescriptorSets(
     VkPipelineBindPoint    pipelineBindPoint,
     VkPipelineLayout       layout,
@@ -1675,7 +1675,7 @@ void CmdBuffer::BindDescriptorSets(
                             setBindingData[apiBindPoint][setLayoutInfo.dynDescDataRegOffset]),
                         pDynamicOffsets,
                         setLayoutInfo.dynDescCount,
-                        robustBufferAccess);
+                        useCompactDescriptor);
 
                     deviceIdx++;
                 } while (deviceIdx < numPalDevices);
@@ -1754,7 +1754,7 @@ VK_INLINE bool CmdBuffer::PalPipelineBindingOwnedBy(
 }
 
 // =====================================================================================================================
-template<uint32_t numPalDevices, bool robustBufferAccess>
+template<uint32_t numPalDevices, bool useCompactDescriptor>
 VKAPI_ATTR void VKAPI_CALL CmdBuffer::CmdBindDescriptorSets(
     VkCommandBuffer                             cmdBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
@@ -1765,7 +1765,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuffer::CmdBindDescriptorSets(
     uint32_t                                    dynamicOffsetCount,
     const uint32_t*                             pDynamicOffsets)
 {
-    ApiCmdBuffer::ObjectFromHandle(cmdBuffer)->BindDescriptorSets<numPalDevices, robustBufferAccess>(
+    ApiCmdBuffer::ObjectFromHandle(cmdBuffer)->BindDescriptorSets<numPalDevices, useCompactDescriptor>(
         pipelineBindPoint,
         layout,
         firstSet,
@@ -1817,7 +1817,7 @@ PFN_vkCmdBindDescriptorSets CmdBuffer::GetCmdBindDescriptorSetsFunc(
 {
     PFN_vkCmdBindDescriptorSets pFunc = nullptr;
 
-    if (pDevice->GetEnabledFeatures().robustBufferAccess)
+    if (pDevice->UseCompactDynamicDescriptors())
     {
         pFunc = CmdBindDescriptorSets<numPalDevices, true>;
     }

--- a/icd/api/vk_descriptor_set.cpp
+++ b/icd/api/vk_descriptor_set.cpp
@@ -319,7 +319,7 @@ void DescriptorUpdate::WriteBufferInfoDescriptors(
     {
         if (pBufferInfo->buffer == VK_NULL_HANDLE)
         {
-            if ((pDevice->GetEnabledFeatures().robustBufferAccess == false) &&
+            if (pDevice->UseCompactDynamicDescriptors() &&
                 ((type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) ||
                  (type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)))
             {
@@ -335,7 +335,7 @@ void DescriptorUpdate::WriteBufferInfoDescriptors(
         {
             info.gpuAddr = Buffer::ObjectFromHandle(pBufferInfo->buffer)->GpuVirtAddr(deviceIdx) + pBufferInfo->offset;
 
-            if ((pDevice->GetEnabledFeatures().robustBufferAccess == false) &&
+            if (pDevice->UseCompactDynamicDescriptors() &&
                 ((type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) ||
                  (type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)))
             {

--- a/icd/api/vk_descriptor_set_layout.cpp
+++ b/icd/api/vk_descriptor_set_layout.cpp
@@ -204,7 +204,7 @@ uint32_t DescriptorSetLayout::GetDynamicBufferDescDwSize(const Device* pDevice)
 {
     // Currently we store the whole buffer SRD in the dynamic section (i.e. user data registers).
     uint32_t size = 0;
-    if (pDevice->GetEnabledFeatures().robustBufferAccess == false)
+    if (pDevice->UseCompactDynamicDescriptors())
     {
         size = sizeof(Pal::gpusize);
     }

--- a/icd/settings/settings_xgl.json
+++ b/icd/settings/settings_xgl.json
@@ -852,6 +852,19 @@
       "VariableName": "delayFullScreenAcquireToFirstPresent"
     },
     {
+      "Name": "EnableRelocatableShaders",
+      "Description": "Builds a pipeline by linking reloctable shader elf, which have been built individually.  Only valid when LLPC is the pipeline compiler.",
+      "Tags": [
+	"SPIRV Options"
+      ],
+      "Defaults": {
+	"Default": false
+      },
+      "Scope": "Driver",
+      "Type": "bool",
+      "VariableName": "enableRelocatableShaders"
+    },
+    {
       "Description": "Enable pipeline dump, pipeline is stored with .pipe format. You must set AMD_DEBUG_DIR and make sure $AMD_DEBUG_DIR + pipelineDumpDir is  an available directory.",
       "Tags": [
         "SPIRV Options"


### PR DESCRIPTION
When we were handling resource descriptors in llpc, relocatable shaders were not able to handle compact descriptors.  This is because the generated code is very different between a compact descriptor and a standard one.  The link step cannot easily rewrite one into the other using a relocation.

This is a problem for us because compact descriptors are currently very common when robust buffer access is turned off.

This PR will add an option to XGL, so that the driver knows when relocatable shaders are being used, and does not use compact buffer descriptors.  I've renamed a few variables because they will be set  when doing relocatable shader even if we are not doing robust buffer access.  I don't think it is a good idea to tie the name too closely to robust buffer access in that case.

Are there any problems with this change?