### PR TITLE
xgl: Fix EXT_conditional_rendering

### DIFF
--- a/icd/api/vk_cmdbuffer.cpp
+++ b/icd/api/vk_cmdbuffer.cpp
@@ -5853,7 +5853,7 @@ void CmdBuffer::CmdBeginConditionalRendering(
             nullptr,
             0,
             pBuffer->PalMemory(deviceGroup.Index()),
-            pConditionalRenderingBegin->offset,
+            pBuffer->MemOffset() + pConditionalRenderingBegin->offset,
             Pal::PredicateType::Boolean32,
             predPolarity,
             false,

--- a/icd/api/vk_physical_device.cpp
+++ b/icd/api/vk_physical_device.cpp
@@ -3355,7 +3355,7 @@ VkResult PhysicalDevice::GetPhysicalDevicePresentRectangles(
 static bool IsConditionalRenderingSupported(
     const PhysicalDevice* pPhysicalDevice)
 {
-    bool isSupported = false;
+    bool isSupported = true;
 
     if (isSupported && (pPhysicalDevice != nullptr))
     {


### PR DESCRIPTION
This PR fixes 2 small issues in XGL's EXT_conditional_rendering code. The extension depends on https://github.com/GPUOpen-Drivers/pal/pull/47 to be functional.