### PR TITLE
Don't use VkInstance and VkPhysicalDevice in PipelineBinaryCache

### DIFF
--- a/icd/api/include/cache_adapter.h
+++ b/icd/api/include/cache_adapter.h
@@ -30,21 +30,19 @@
 */
 #pragma once
 
-#include "include/vk_instance.h"
-#include "pipeline_binary_cache.h"
 #include "vkgcDefs.h"
 
 namespace vk
 {
 using namespace Vkgc;
 
+class PipelineBinaryCache;
+
 // An adapter class that implements ICache in terms of a simple Get/Set interface.
 class CacheAdapter : public ICache
 {
 public:
-    static CacheAdapter* Create(
-        Instance*                   pInstance,
-        PipelineBinaryCache*        pPipelineBinaryCache);
+    static CacheAdapter* Create(PipelineBinaryCache* pPipelineBinaryCache);
 
     ~CacheAdapter();
     void Destroy();
@@ -71,11 +69,8 @@ public:
                             size_t* pDataLen) override;
 
 private:
-    explicit CacheAdapter(
-        Instance*                 pInstance,
-        PipelineBinaryCache*      pPipelineBinaryCache);
+    explicit CacheAdapter(PipelineBinaryCache* pPipelineBinaryCache);
 
-    Instance*   m_pInstance;
     PipelineBinaryCache* m_pPipelineBinaryCache;
 };
 

--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -104,7 +104,6 @@ void PipelineCompiler::DestroyPipelineBinaryCache()
     if (m_pBinaryCache != nullptr)
     {
         m_pBinaryCache->Destroy();
-        m_pPhysicalDevice->VkInstance()->FreeMem(m_pBinaryCache);
         m_pBinaryCache = nullptr;
     }
 }
@@ -169,7 +168,17 @@ VkResult PipelineCompiler::Initialize()
          (m_pPhysicalDevice->VkInstance()->GetDevModeMgr() != nullptr)))
     {
         m_pBinaryCache = PipelineBinaryCache::Create(
-                m_pPhysicalDevice->VkInstance(), 0, nullptr, true, m_gfxIp, m_pPhysicalDevice);
+                m_pPhysicalDevice->VkInstance()->GetAllocCallbacks(),
+                m_pPhysicalDevice->GetPlatformKey(),
+                m_gfxIp,
+                m_pPhysicalDevice->GetRuntimeSettings(),
+                m_pPhysicalDevice->PalDevice()->GetCacheFilePath(),
+#if ICD_GPUOPEN_DEVMODE_BUILD
+                m_pPhysicalDevice->VkInstance()->GetDevModeMgr(),
+#endif
+                0,
+                nullptr,
+                true);
 
         // This isn't a terminal failure, the device can continue without the pipeline cache if need be.
         VK_ALERT(m_pBinaryCache == nullptr);


### PR DESCRIPTION
This refactoring in preparation to be able to use PipelineBinaryCache in
an offline tool, without having to run with a Vulkan device installed.

See https://github.com/GPUOpen-Drivers/xgl/issues/64 for more details on
the high-level direction.