### PR TITLE
Report cache access information

### DIFF
--- a/icd/api/include/compiler_solution.h
+++ b/icd/api/include/compiler_solution.h
@@ -87,6 +87,7 @@ struct GraphicsPipelineCreateInfo
     bool                                   freeWithCompiler;
     Util::MetroHash::Hash                  basePipelineHash;
     PipelineCreationFeedback               pipelineFeedback;
+    PipelineCreationFeedback               stageFeedback[ShaderStage::ShaderStageGfxCount];
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 41
     Vkgc::ResourceMappingData              resourceMapping;
 #endif
@@ -105,6 +106,7 @@ struct ComputePipelineCreateInfo
     bool                                   freeWithCompiler;
     Util::MetroHash::Hash                  basePipelineHash;
     PipelineCreationFeedback               pipelineFeedback;
+    PipelineCreationFeedback               stageFeedback;
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 41
     Vkgc::ResourceMappingData              resourceMapping;
 #endif

--- a/icd/api/include/compiler_solution_llpc.h
+++ b/icd/api/include/compiler_solution_llpc.h
@@ -110,6 +110,11 @@ public:
         size_t                      binarySize) override;
 private:
     VkResult CreateLlpcCompiler(Vkgc::ICache* pCache);
+    void UpdateStageCreationFeedback(
+        PipelineCreationFeedback*       pStageFeedback,
+        const Vkgc::PipelineShaderInfo& shader,
+        const Llpc::CacheAccessInfo*    pStageCacheAccesses,
+        ShaderStage                     stage);
 
 private:
     Llpc::ICompiler*    m_pLlpc;               // LLPC compiler object

--- a/icd/api/include/pipeline_compiler.h
+++ b/icd/api/include/pipeline_compiler.h
@@ -114,9 +114,16 @@ public:
         const void**                        ppPipelineBinary,
         Util::MetroHash::Hash*              pCacheId);
 
+    void UpdatePipelineCreationFeedback(
+        VkPipelineCreationFeedbackEXT*  pPipelineCreationFeedback,
+        const PipelineCreationFeedback* pFeedbackFromCompiler);
+
     VkResult SetPipelineCreationFeedbackInfo(
         const VkPipelineCreationFeedbackCreateInfoEXT* pPipelineCreationFeadbackCreateInfo,
-        const PipelineCreationFeedback*                pPipelineFeedback);
+        uint32_t                                       stageCount,
+        const VkPipelineShaderStageCreateInfo*         pStages,
+        const PipelineCreationFeedback*                pPipelineFeedback,
+        const PipelineCreationFeedback*                pStageFeedback);
 
     VkResult ConvertGraphicsPipelineInfo(
         Device*                                         pDevice,

--- a/icd/api/vk_compute_pipeline.cpp
+++ b/icd/api/vk_compute_pipeline.cpp
@@ -329,7 +329,10 @@ VkResult ComputePipeline::Create(
         binaryCreateInfo.pipelineFeedback.duration = duration;
         pDefaultCompiler->SetPipelineCreationFeedbackInfo(
                 pPipelineCreationFeadbackCreateInfo,
-                &binaryCreateInfo.pipelineFeedback);
+                0,
+                nullptr,
+                &binaryCreateInfo.pipelineFeedback,
+                &binaryCreateInfo.stageFeedback);
 
         const RuntimeSettings& settings = pDevice->GetRuntimeSettings();
         // The hash is same as pipline dump file name, we can easily analyze further.

--- a/icd/api/vk_graphics_pipeline.cpp
+++ b/icd/api/vk_graphics_pipeline.cpp
@@ -1445,7 +1445,10 @@ VkResult GraphicsPipeline::Create(
             {
                 pDefaultCompiler->SetPipelineCreationFeedbackInfo(
                     pPipelineCreationFeadbackCreateInfo,
-                    &binaryCreateInfoMGPU.pipelineFeedback);
+                    pCreateInfo->stageCount,
+                    pCreateInfo->pStages,
+                    &binaryCreateInfoMGPU.pipelineFeedback,
+                    binaryCreateInfoMGPU.stageFeedback);
             }
 
             pDefaultCompiler->FreeGraphicsPipelineCreateInfo(&binaryCreateInfoMGPU);
@@ -1698,7 +1701,10 @@ VkResult GraphicsPipeline::Create(
         binaryCreateInfo.pipelineFeedback.duration = duration;
         pDefaultCompiler->SetPipelineCreationFeedbackInfo(
             pPipelineCreationFeadbackCreateInfo,
-            &binaryCreateInfo.pipelineFeedback);
+            pCreateInfo->stageCount,
+            pCreateInfo->pStages,
+            &binaryCreateInfo.pipelineFeedback,
+            binaryCreateInfo.stageFeedback);
 
         // The hash is same as pipline dump file name, we can easily analyze further.
         AmdvlkLog(settings.logTagIdMask, PipelineCompileTime, "0x%016llX-%llu", pipelineHash, duration);


### PR DESCRIPTION
Based on the Vulkan spec, Vulkan application can get the cache hit/miss
information for the pipeline and all shader stages using
[Pipeline Creation Feedback](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/chap11.html#pipelines-creation-feedback).

This commit lets XGL report the cache hit/miss information through
`VkPipelineCreationFeedbackCreateInfoEXT` data structure.

Since LLPC uses/maintains the pipeline and the shader caches, LLPC
passes the cache hit/miss information to XGL.
[This PR](https://github.com/GPUOpen-Drivers/llpc/pull/1061) lets LLPC conduct it.