### PR TITLE
Move pipeline cache serialization code to a new xgl (sub)library

### DIFF
--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -495,6 +495,19 @@ endif()
 
 target_link_libraries(xgl PRIVATE pal)
 
+### XGL cache_support ####
+add_library(xgl_cache_support INTERFACE)
+
+target_sources(xgl_cache_support INTERFACE
+    api/binary_cache_serialization.cpp
+)
+target_include_directories(xgl_cache_support INTERFACE
+    api
+)
+target_link_libraries(xgl_cache_support INTERFACE pal)
+
+target_link_libraries(xgl PRIVATE xgl_cache_support)
+
 ### Visual Studio Filters ##############################################################################################
 target_find_headers(xgl)
 if(MSVC)

--- a/icd/api/binary_cache_serialization.cpp
+++ b/icd/api/binary_cache_serialization.cpp
@@ -1,0 +1,233 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2018-2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+/**
+***********************************************************************************************************************
+* @file  binary_cache_serialization.cpp
+* @brief Implementation of pipeline binary cache serialization in the xgl_cache_support library.
+***********************************************************************************************************************
+*/
+#include "binary_cache_serialization.h"
+
+#include "palAssert.h"
+#include "palInlineFuncs.h"
+#include "palPlatformKey.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace vk
+{
+
+// =====================================================================================================================
+// Writes Vulkan pipeline cache data object header into the provided output buffer.
+Util::Result WriteVkPipelineCacheHeaderData(
+    void*    pOutputBuffer,
+    size_t   bufferSize,
+    uint32_t vendorId,
+    uint32_t deviceId,
+    uint8_t* pUuid,
+    size_t   uuidSize,
+    size_t*  pBytesWritten
+)
+{
+    PAL_ASSERT(pOutputBuffer != nullptr);
+    PAL_ASSERT(pUuid != nullptr);
+    PAL_ASSERT(uuidSize == sizeof(PipelineCacheHeaderData::UUID));
+
+    Util::Result result = Util::Result::ErrorIncompleteResults;
+
+    if (bufferSize < VkPipelineCacheHeaderDataSize)
+    {
+        if (pBytesWritten != nullptr)
+        {
+            *pBytesWritten = 0;
+        }
+    }
+    else
+    {
+        PipelineCacheHeaderData header = {};
+        static_assert(VkPipelineCacheHeaderDataSize == sizeof(header), "Size assumptions changed!");
+        header.headerLength = VkPipelineCacheHeaderDataSize;
+        header.headerVersion = VK_PIPELINE_CACHE_HEADER_VERSION_ONE;
+        header.vendorID = vendorId;
+        header.deviceID = deviceId;
+        memcpy(header.UUID, pUuid, sizeof(header.UUID));
+
+        memcpy(pOutputBuffer, &header, VkPipelineCacheHeaderDataSize);
+
+        if (pBytesWritten != nullptr)
+        {
+            *pBytesWritten = VkPipelineCacheHeaderDataSize;
+        }
+        result = Util::Result::Success;
+    }
+    return result;
+}
+
+// =====================================================================================================================
+Util::Result CalculatePipelineBinaryCacheHashId(
+    VkAllocationCallbacks*    pAllocationCallbacks,
+    const Util::IPlatformKey* pPlatformKey,
+    const void*               pCacheData,
+    size_t                    dataSize,
+    uint8_t*                  pHashId)
+{
+    Util::Result        result       = Util::Result::Success;
+    Util::IHashContext* pContext     = nullptr;
+    size_t              contextSize  = pPlatformKey->GetKeyContext()->GetDuplicateObjectSize();
+    void*               pContextMem  = pAllocationCallbacks->pfnAllocation(pAllocationCallbacks->pUserData,
+                                                                           contextSize,
+                                                                           16,
+                                                                           VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
+
+    if (pContextMem != nullptr)
+    {
+        result = pPlatformKey->GetKeyContext()->Duplicate(pContextMem, &pContext);
+    }
+    if (result == Util::Result::Success)
+    {
+        result = pContext->AddData(pCacheData, dataSize);
+    }
+    if (result == Util::Result::Success)
+    {
+        result = pContext->Finish(pHashId);
+    }
+    if (pContext != nullptr)
+    {
+        pContext->Destroy();
+    }
+    if (pContextMem != nullptr)
+    {
+        pAllocationCallbacks->pfnFree(pAllocationCallbacks->pUserData, pContextMem);
+    }
+
+    return result;
+}
+
+// =====================================================================================================================
+// Returns Util::Result::Success on success or Util::Result::ErrorInvalidMemorySize if the provided buffer is too small
+// to create a valid pipeline binary cache blob.
+Util::Result PipelineBinaryCacheSerializer::Initialize(
+    size_t bufferCapacity,
+    void*  pOutputBuffer)
+{
+    PAL_ASSERT(pOutputBuffer != nullptr);
+
+    Util::Result result = Util::Result::ErrorInvalidMemorySize;
+
+    m_pOutputBuffer = pOutputBuffer;
+    if (bufferCapacity >= HeaderSize)
+    {
+        m_bufferCapacity = bufferCapacity;
+        m_bytesUsed = HeaderSize;
+        result = Util::Result::Success;
+    }
+    return result;
+}
+
+// =====================================================================================================================
+// Copies the provided data into the internal buffer.
+Util::Result PipelineBinaryCacheSerializer::AddPipelineBinary(
+    const BinaryCacheEntry* pEntry,
+    const void*             pData)
+{
+    PAL_ASSERT(pEntry != nullptr);
+    PAL_ASSERT(pData != nullptr);
+
+    Util::Result result = Util::Result::ErrorIncompleteResults;
+    const size_t bytesToWrite = EntryHeaderSize + pEntry->dataSize;
+    if (bytesToWrite <= (m_bufferCapacity - m_bytesUsed))
+    {
+        void *pOutputMem = Util::VoidPtrInc(m_pOutputBuffer, m_bytesUsed);
+        memcpy(pOutputMem, pEntry, EntryHeaderSize);
+        pOutputMem = Util::VoidPtrInc(pOutputMem, EntryHeaderSize);
+        memcpy(pOutputMem, pData, pEntry->dataSize);
+        m_bytesUsed += bytesToWrite;
+        ++m_numEntries;
+        result = Util::Result::Success;
+    }
+
+    return result;
+}
+
+// =====================================================================================================================
+// Writes a pipeline binary cache header based on the added data entries, producing a valid pipeline binary cache blob.
+// No further data entries can be added after calling Finalize.
+Util::Result PipelineBinaryCacheSerializer::Finalize(
+    VkAllocationCallbacks*    pAllocationCallbacks,
+    const Util::IPlatformKey* pKey,
+    size_t*                   pCacheEntriesWritten,
+    size_t*                   pBytesWritten)
+{
+    PAL_ASSERT(pAllocationCallbacks != nullptr);
+    PAL_ASSERT(pKey != nullptr);
+
+    auto pPrivateHeader         = static_cast<PipelineBinaryCachePrivateHeader*>(m_pOutputBuffer);
+    void *pCacheDataBegin       = Util::VoidPtrInc(m_pOutputBuffer, HeaderSize);
+    const size_t cacheDataBytes = m_bytesUsed - HeaderSize;
+
+    if (pCacheEntriesWritten != nullptr)
+    {
+        *pCacheEntriesWritten = m_numEntries;
+    }
+    if (pBytesWritten != nullptr)
+    {
+        *pBytesWritten = m_bytesUsed;
+    }
+
+    return CalculatePipelineBinaryCacheHashId(pAllocationCallbacks,
+                                              pKey,
+                                              pCacheDataBegin,
+                                              cacheDataBytes,
+                                              pPrivateHeader->hashId);
+}
+
+}

--- a/icd/api/include/binary_cache_serialization.h
+++ b/icd/api/include/binary_cache_serialization.h
@@ -1,0 +1,163 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2018-2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+/**
+***********************************************************************************************************************
+* @file  binary_cache_serialization.h
+* @brief Declaration of pipeline binary cache serialization interface in the xgl_cache_support library.
+***********************************************************************************************************************
+*/
+#pragma once
+
+#include "include/khronos/vulkan.h"
+#include "include/vk_defines.h"
+#include "palMetroHash.h"
+#include "palUtil.h"
+
+#include <cstddef>
+#include <cstdint>
+
+struct VkAllocationCallbacks;
+
+namespace Util
+{
+class IPlatformKey;
+}
+
+namespace vk
+{
+
+// Layout for pipeline cache header version VK_PIPELINE_CACHE_HEADER_VERSION_ONE, all fields are written with LSB first.
+struct PipelineCacheHeaderData
+{
+    uint32_t headerLength;       // Length in bytes of the entire pipeline cache header.
+    uint32_t headerVersion;      // A VkPipelineCacheHeaderVersion value.
+    uint32_t vendorID;           // A vendor ID equal to VkPhysicalDeviceProperties::vendorID.
+    uint32_t deviceID;           // A device ID equal to VkPhysicalDeviceProperties::deviceID.
+    uint8_t  UUID[VK_UUID_SIZE]; // A pipeline cache ID equal to VkPhysicalDeviceProperties::pipelineCacheUUID.
+};
+
+constexpr size_t VkPipelineCacheHeaderDataSize = sizeof(PipelineCacheHeaderData);
+
+Util::Result WriteVkPipelineCacheHeaderData(
+    void*    pOutputBuffer,
+    size_t   bufferSize,
+    uint32_t vendorId,
+    uint32_t deviceId,
+    uint8_t* pUuid,
+    size_t   uuidSize,
+    size_t*  pBytesWritten
+);
+
+// Layout for pipeline binary cache entry header, all fields are written with LSB first.
+struct BinaryCacheEntry
+{
+    Util::MetroHash::Hash hashId;
+    size_t                dataSize;
+};
+
+// Layout for pipeline binary cache header, all fields are written with LSB first.
+constexpr size_t SHA_DIGEST_LENGTH = 20;
+struct PipelineBinaryCachePrivateHeader
+{
+    uint8_t  hashId[SHA_DIGEST_LENGTH];
+};
+
+Util::Result CalculatePipelineBinaryCacheHashId(
+    VkAllocationCallbacks*    pAllocationCallbacks,
+    const Util::IPlatformKey* pPlatformKey,
+    const void*               pCacheData,
+    size_t                    dataSize,
+    uint8_t*                  pHashId);
+
+// =====================================================================================================================
+// Class for serializing in-memory cache data into valid pipeline binary cache blobs.
+class PipelineBinaryCacheSerializer
+{
+public:
+    // Returns an upper bound for the size of the final pipeline binary cache blob.
+    // This can be used to create an appropriately-sized buffer for the serialized pipeline binary cache.
+    // Note that this doesn't take into account the Vulkan pipeline cache data.
+    static size_t CalculateAnticipatedCacheBlobSize(
+        size_t numEntries,
+        size_t totalPipelineBinariesSize)
+    {
+        return HeaderSize + (numEntries * EntryHeaderSize) + totalPipelineBinariesSize;
+    }
+
+    PipelineBinaryCacheSerializer() = default;
+
+    Util::Result Initialize(
+        size_t bufferCapacity,
+        void*  pOutputBuffer);
+
+    Util::Result AddPipelineBinary(
+        const BinaryCacheEntry* pEntry,
+        const void*             pData);
+
+    Util::Result Finalize(
+        VkAllocationCallbacks*    pAllocationCallbacks,
+        const Util::IPlatformKey* pKey,
+        size_t*                   pCacheEntriesWritten,
+        size_t*                   pBytesWritten);
+
+private:
+    PAL_DISALLOW_COPY_AND_ASSIGN(PipelineBinaryCacheSerializer);
+
+    static constexpr size_t HeaderSize      = sizeof(PipelineBinaryCachePrivateHeader);
+    static constexpr size_t EntryHeaderSize = sizeof(BinaryCacheEntry);
+
+    size_t m_numEntries     = 0;
+    void*  m_pOutputBuffer  = nullptr;
+    size_t m_bufferCapacity = 0;
+    size_t m_bytesUsed      = 0;
+};
+
+}

--- a/icd/api/include/compiler_solution.h
+++ b/icd/api/include/compiler_solution.h
@@ -48,12 +48,6 @@ class PhysicalDevice;
 class PipelineCache;
 class ShaderCache;
 
-// Enumerates the compiler types
-enum PipelineCompilerType : uint32_t
-{
-    PipelineCompilerTypeLlpc,  // Use shader compiler provided by LLPC
-};
-
 // Represents the result of PipelineCompiler::BuildShaderModule
 struct ShaderModuleHandle
 {

--- a/icd/api/include/pipeline_binary_cache.h
+++ b/icd/api/include/pipeline_binary_cache.h
@@ -50,17 +50,6 @@ namespace vk
 {
 
 class CacheAdapter;
-struct BinaryCacheEntry
-{
-    Util::MetroHash::Hash hashId;
-    size_t                dataSize;
-};
-
-constexpr size_t SHA_DIGEST_LENGTH = 20;
-struct PipelineBinaryCachePrivateHeader
-{
-    uint8_t  hashId[SHA_DIGEST_LENGTH];
-};
 
 // Unified pipeline cache interface
 class PipelineBinaryCache
@@ -86,13 +75,6 @@ public:
         Util::IPlatformKey*    pKey,
         size_t                 dataSize,
         const void*            pData);
-
-    static Util::Result CalculateHashId(
-        VkAllocationCallbacks*    pAllocationCallbacks,
-        const Util::IPlatformKey* pPlatformKey,
-        const void*               pData,
-        size_t                    dataSize,
-        uint8_t*                  pHashId);
 
     ~PipelineBinaryCache();
 

--- a/icd/api/include/vk_defines.h
+++ b/icd/api/include/vk_defines.h
@@ -193,6 +193,12 @@ namespace vk
     // The default, full stencil write mask
     static const uint8_t StencilWriteMaskFull = 0xFF;
 
+    // Enumerates the compiler types
+    enum PipelineCompilerType : uint32_t
+    {
+        PipelineCompilerTypeLlpc,  // Use shader compiler provided by LLPC
+    };
+
 }// namespace vk
 
 #endif

--- a/icd/api/include/vk_pipeline_cache.h
+++ b/icd/api/include/vk_pipeline_cache.h
@@ -28,28 +28,18 @@
 #include "include/vk_utils.h"
 #include "include/vk_defines.h"
 #include "include/vk_dispatch.h"
+#include "include/pipeline_binary_cache.h"
 #include "include/pipeline_compiler.h"
-#include "pipeline_binary_cache.h"
 
 namespace vk
 {
 
 class Device;
 
-// Layout for pipeline cache header version VK_PIPELINE_CACHE_HEADER_VERSION_ONE, all fields are written with LSB first.
-struct PipelineCacheHeaderData
-{
-    uint32_t headerLength;       // Length in bytes of the entire pipeline cache header.
-    uint32_t headerVersion;      // A VkPipelineCacheHeaderVersion value.
-    uint32_t vendorID;           // A vendor ID equal to VkPhysicalDeviceProperties::vendorID.
-    uint32_t deviceID;           // A device ID equal to VkPhysicalDeviceProperties::deviceID.
-    uint8_t  UUID[VK_UUID_SIZE]; // A pipeline cache ID equal to VkPhysicalDeviceProperties::pipelineCacheUUID.
-};
-
 // Layout for pipeline cache private header, all fields are written with LSB first.
 struct PipelineCachePrivateHeaderData
 {
-    PipelineCompilerType cacheType;        // Cache data type
+    PipelineCompilerType cacheType;     // Cache data type
     uint64_t blobSize[MaxPalDevices];   // Blob data size for each device
 };
 

--- a/icd/api/pipeline_binary_cache.cpp
+++ b/icd/api/pipeline_binary_cache.cpp
@@ -29,6 +29,7 @@
 ***********************************************************************************************************************
 */
 #include "include/pipeline_binary_cache.h"
+#include "include/binary_cache_serialization.h"
 
 #include "palArchiveFile.h"
 #include "palAutoBuffer.h"
@@ -37,6 +38,7 @@
 #include "palVectorImpl.h"
 #include "palHashMapImpl.h"
 #include "palFile.h"
+
 #if ICD_GPUOPEN_DEVMODE_BUILD
 #include "palPipelineAbiReader.h"
 #include "devmode/devmode_mgr.h"
@@ -76,44 +78,6 @@ const uint32_t PipelineBinaryCache::ElfType     = Util::HashString(ElfTypeString
 static Util::Hash128 ParseHash128(const char* str);
 #endif
 
-Util::Result PipelineBinaryCache::CalculateHashId(
-    VkAllocationCallbacks*    pAllocationCallbacks,
-    const Util::IPlatformKey* pPlatformKey,
-    const void*               pData,
-    size_t                    dataSize,
-    uint8_t*                  pHashId)
-{
-    Util::Result        result       = Util::Result::Success;
-    Util::IHashContext* pContext     = nullptr;
-    size_t              contextSize  = pPlatformKey->GetKeyContext()->GetDuplicateObjectSize();
-    void*               pContextMem  = pAllocationCallbacks->pfnAllocation(pAllocationCallbacks->pUserData,
-                                                                           contextSize,
-                                                                           VK_DEFAULT_MEM_ALIGN,
-                                                                           VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
-
-    if (pContextMem != nullptr)
-    {
-        result = pPlatformKey->GetKeyContext()->Duplicate(pContextMem, &pContext);
-    }
-    if (result == Util::Result::Success)
-    {
-        result = pContext->AddData(pData, dataSize);
-    }
-    if (result == Util::Result::Success)
-    {
-        result = pContext->Finish(pHashId);
-    }
-    if (pContext != nullptr)
-    {
-        pContext->Destroy();
-    }
-    if (pContextMem != nullptr)
-    {
-        pAllocationCallbacks->pfnFree(pAllocationCallbacks->pUserData, pContextMem);
-    }
-
-    return result;
-}
 
 bool PipelineBinaryCache::IsValidBlob(
     VkAllocationCallbacks* pAllocationCallbacks,
@@ -133,11 +97,12 @@ bool PipelineBinaryCache::IsValidBlob(
         pData         = Util::VoidPtrInc(pData, sizeof(PipelineBinaryCachePrivateHeader));
         blobSize     -= sizeof(PipelineBinaryCachePrivateHeader);
 
-        Util::Result result = CalculateHashId(pAllocationCallbacks,
-                                              pKey,
-                                              pData,
-                                              blobSize,
-                                              hashId);
+        Util::Result result = CalculatePipelineBinaryCacheHashId(
+                                pAllocationCallbacks,
+                                pKey,
+                                pData,
+                                blobSize,
+                                hashId);
 
         if (result == Util::Result::Success)
         {
@@ -1345,7 +1310,7 @@ VkResult PipelineBinaryCache::Serialize(
             result = PalToVkResult(Util::GetMemoryCacheLayerCurSize(m_pMemoryLayer, &curCount, &curDataSize));
             if (result == VK_SUCCESS)
             {
-                *pSize = curCount * sizeof(BinaryCacheEntry) + curDataSize + sizeof(PipelineBinaryCachePrivateHeader);
+                *pSize = PipelineBinaryCacheSerializer::CalculateAnticipatedCacheBlobSize(curCount, curDataSize);
             }
         }
         else
@@ -1355,58 +1320,27 @@ VkResult PipelineBinaryCache::Serialize(
             result = PalToVkResult(Util::GetMemoryCacheLayerCurSize(m_pMemoryLayer, &curCount, &curDataSize));
             if (result == VK_SUCCESS)
             {
-                if (*pSize > (sizeof(BinaryCacheEntry) + sizeof(PipelineBinaryCachePrivateHeader)))
+                PipelineBinaryCacheSerializer serializer;
+                if (serializer.Initialize(*pSize, pBlob) == Util::Result::Success)
                 {
                     Util::AutoBuffer<Util::Hash128, 8, PalAllocator> cacheIds(curCount, &m_palAllocator);
-                    size_t remainingSpace    = *pSize - sizeof(PipelineBinaryCachePrivateHeader);
-
                     result = PalToVkResult(Util::GetMemoryCacheLayerHashIds(m_pMemoryLayer, curCount, &cacheIds[0]));
-                    if (result == VK_SUCCESS)
+                    for (uint32_t i = 0; result == VK_SUCCESS && i < curCount; i++)
                     {
-                        void* pDataDst = pBlob;
+                        const void*      pBinaryCacheData = nullptr;
+                        BinaryCacheEntry entry            = {cacheIds[i], 0};
 
-                        // reserved for privateHeader
-                        pDataDst = Util::VoidPtrInc(pDataDst, sizeof(PipelineBinaryCachePrivateHeader));
-
-                        for (uint32_t i = 0; i < curCount && remainingSpace > sizeof(BinaryCacheEntry); i++)
+                        result = PalToVkResult(LoadPipelineBinary(&entry.hashId, &entry.dataSize, &pBinaryCacheData));
+                        if (result == VK_SUCCESS)
                         {
-                            size_t           dataSize;
-                            const void*      pBinaryCacheData;
-
-                            result = PalToVkResult(LoadPipelineBinary(&cacheIds[i], &dataSize, &pBinaryCacheData));
-                            if (result == VK_SUCCESS)
-                            {
-                                if (remainingSpace >= (sizeof(BinaryCacheEntry) + dataSize))
-                                {
-                                    BinaryCacheEntry* pEntry =  static_cast<BinaryCacheEntry*>(pDataDst);
-
-                                    pEntry->hashId    = cacheIds[i];
-                                    pEntry->dataSize  = dataSize;
-
-                                    pDataDst = Util::VoidPtrInc(pDataDst, sizeof(BinaryCacheEntry));
-                                    memcpy(pDataDst, pBinaryCacheData, dataSize);
-                                    pDataDst = Util::VoidPtrInc(pDataDst, dataSize);
-                                    remainingSpace -= (sizeof(BinaryCacheEntry) + dataSize);
-                                }
-                                FreeMem(const_cast<void*>(pBinaryCacheData));
-                            }
+                            result = PalToVkResult(serializer.AddPipelineBinary(&entry, pBinaryCacheData));
+                            FreeMem(const_cast<void*>(pBinaryCacheData));
                         }
                     }
-                    if (*pSize < (sizeof(BinaryCacheEntry) * curCount + curDataSize + sizeof(PipelineBinaryCachePrivateHeader)))
-                    {
-                        result = VK_INCOMPLETE;
-                    }
-                    *pSize -= remainingSpace;
-
-                    auto pBinaryPrivateHeader = static_cast<PipelineBinaryCachePrivateHeader*>(pBlob);
-                    void* pData               = Util::VoidPtrInc(pBlob, sizeof(PipelineBinaryCachePrivateHeader));
-
-                    result = PalToVkResult(CalculateHashId(
-                                                m_pAllocationCallbacks,
-                                                m_pPlatformKey,
-                                                pData,
-                                                *pSize - sizeof(PipelineBinaryCachePrivateHeader),
-                                                pBinaryPrivateHeader->hashId));
+                    result = PalToVkResult(serializer.Finalize(m_pAllocationCallbacks,
+                                                               m_pPlatformKey,
+                                                               nullptr,
+                                                               nullptr));
                 }
                 else
                 {


### PR DESCRIPTION
This is to be able to use the same serialization code in both the ICD and the
cache creator tool. By creating a new support library, we won't have to link
with the whole XGL and will know exactly the XGL APIs used by cache creator.