### PR TITLE
Add cache creator tool target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,8 @@ option(XGL_BUILD_GFX103 "Build open source vulkan for GFX103" ON)
 
 cmake_dependent_option(XGL_BUILD_NAVI21 "Build open source vulkan for Navi21" ON "XGL_BUILD_GFX10;XGL_BUILD_GFX103" OFF)
 
+option(XGL_BUILD_CACHE_CREATOR "Build cache-creator tools?" OFF)
+
 #if VKI_KHR_SHADER_SUBGROUP_EXTENDED_TYPES
 option(VKI_KHR_SHADER_SUBGROUP_EXTENDED_TYPES "Build vulkan with KHR_SHADER_SUBGROUP_EXTENDED_TYPES" OFF)
 #endif
@@ -367,6 +369,9 @@ if(ICD_GPUOPEN_DEVMODE_BUILD)
     endif()
     set(GPUOPEN_CLIENT_INTERFACE_MAJOR_VERSION ${GPUOPEN_MAJOR_VERSION})
 endif()
+
+# XGL cache creator tool
+set(XGL_CACHE_CREATOR_PATH ${PROJECT_SOURCE_DIR}/tools/cache_creator CACHE PATH "Path to the cache creator tool")
 
 # PAL
 if(EXISTS ${PROJECT_SOURCE_DIR}/../pal)

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -233,6 +233,14 @@ endif()
 ### PAL ########################################################################
 add_subdirectory(${XGL_PAL_PATH} ${PROJECT_BINARY_DIR}/pal)
 
+### XGL cache creator tool ####################################################
+if(XGL_BUILD_CACHE_CREATOR)
+    if(NOT ICD_BUILD_LLPC)
+        message(FATAL_ERROR "Cannot build cache-creator tools without LLPC")
+    endif()
+    add_subdirectory(${XGL_CACHE_CREATOR_PATH} ${CMAKE_BINARY_DIR}/tools)
+endif()
+
 ### XGL Sources ########################################################################################################
 
 ### ICD api ####################################################################

--- a/tools/cache_creator/.clang-format
+++ b/tools/cache_creator/.clang-format
@@ -1,0 +1,13 @@
+BasedOnStyle: LLVM
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: InlineOnly
+IncludeBlocks: Merge
+IncludeCategories:
+  - Regex:           '^"include/'
+    Priority:        2
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        3
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        4
+  - Regex:           '.*'
+    Priority:        1

--- a/tools/cache_creator/CMakeLists.txt
+++ b/tools/cache_creator/CMakeLists.txt
@@ -1,0 +1,67 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+# Cache creator is a tool for building pipeline binary cache files out of shader/pipeline elf files.
+# These input elf files can be compiled offline and packaged as cache file on a host machine without a GPU.
+# The "XGL_BUILD_CACHE_CREATOR" CMake option enables the cache creator targets.
+
+# This interface library is intended be used by the cache creator tool and by the related unit tests.
+add_library(cache_creator_lib INTERFACE)
+
+list(APPEND CMAKE_MODULE_PATH "${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm")
+include(LLVMConfig)
+
+# Find all the LLVM libraries necessary to use the LLVM components that we use.
+# See https://llvm.org/docs/CMake.html#embedding-llvm-in-your-project.
+llvm_map_components_to_libnames(llvm_libs Support)
+target_link_libraries(cache_creator_lib INTERFACE pal ${llvm_libs})
+
+target_include_directories(cache_creator_lib INTERFACE
+    ${XGL_LLVM_SRC_PATH}/include
+    ${LLVM_INCLUDE_DIRS}  # This is necessary to discover the auto-generated llvm-config.h header.
+)
+
+get_target_property(XGL_COMPILE_OPTIONS xgl COMPILE_OPTIONS)
+get_target_property(XGL_COMPILE_DEFINITIONS xgl COMPILE_DEFINITIONS)
+
+# Compile with the same flags and definitions as the ICD and LLVM.
+target_compile_definitions(cache_creator_lib INTERFACE ${LLVM_DEFINITIONS})
+target_compile_definitions(cache_creator_lib INTERFACE ${XGL_COMPILE_DEFINITIONS})
+target_compile_options(cache_creator_lib INTERFACE ${XGL_COMPILE_OPTIONS})
+
+target_sources(cache_creator_lib INTERFACE cache_creator.cpp)
+
+# This executable takes AMDGPU elf files as input and outputs a Vulkan cache file blob
+# that can be later loaded by the ICD.
+# The `cache-creator` binary follows the standard llvm-based tool naming convention.
+# Note that running the cache creator tool doesn't require a Vulkan device to be installed.
+add_executable(cache-creator)
+target_sources(cache-creator PRIVATE cache_creator_main.cpp)
+target_link_libraries(cache-creator PRIVATE cache_creator_lib)
+
+# Build cache-creator whenever we build XGL.
+add_dependencies(xgl cache-creator)
+
+# TODO: Add unit tests.

--- a/tools/cache_creator/cache_creator.cpp
+++ b/tools/cache_creator/cache_creator.cpp
@@ -1,0 +1,34 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+#include "cache_creator.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace cc {
+
+void printNotImplemented() {
+  llvm::errs() << "Cache creator not implemented!\n";
+}
+
+} // namespace cc

--- a/tools/cache_creator/cache_creator.h
+++ b/tools/cache_creator/cache_creator.h
@@ -1,0 +1,31 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+#pragma once
+
+namespace cc {
+
+void printNotImplemented();
+
+} // namespace cc

--- a/tools/cache_creator/cache_creator_main.cpp
+++ b/tools/cache_creator/cache_creator_main.cpp
@@ -1,0 +1,62 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+#include "cache_creator.h"
+#include "palPlatformKey.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/CommandLine.h"
+#include <cassert>
+#include <string>
+
+namespace {
+llvm::cl::OptionCategory CacheCreatorCat("Cache Creator Options");
+
+llvm::cl::list<std::string> InFiles(llvm::cl::Positional, llvm::cl::OneOrMore, llvm::cl::ValueRequired,
+                                    llvm::cl::cat(CacheCreatorCat), llvm::cl::desc("<Input elf file(s)>"));
+llvm::cl::opt<std::string> OutFileName("o", llvm::cl::desc("Output filename"), llvm::cl::cat(CacheCreatorCat),
+                                       llvm::cl::value_desc("filename"), llvm::cl::Required);
+llvm::cl::opt<std::string> DeviceIdStr("device-id", llvm::cl::desc("Device ID"), llvm::cl::cat(CacheCreatorCat));
+llvm::cl::opt<std::string> UUIDStr("uuid", llvm::cl::desc("UUID for the specific driver and machine"),
+                                   llvm::cl::cat(CacheCreatorCat));
+} // namespace
+
+int main(int argc, char **argv) {
+  for (auto &strOptionPair : llvm::cl::getRegisteredOptions()) {
+    auto *opt = strOptionPair.second;
+
+    if (opt && llvm::none_of(opt->Categories, [](const llvm::cl::OptionCategory *category) {
+          return category && (category == &CacheCreatorCat || category->getName() == "Generic Options");
+        })) {
+      opt->setHiddenFlag(llvm::cl::Hidden);
+    }
+  }
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  Util::IPlatformKey *key = nullptr;
+  (void)key;
+
+  cc::printNotImplemented();
+  assert(false && "Not implemented");
+  return 1;
+}


### PR DESCRIPTION
Add initial source and cmake files for the cache creator tool.
At this point, the tool doesn't have any functionality and is meant
to only check that the build system is set up correctly.