### PR TITLE
Add initial cache-creator tool implementation

### DIFF
--- a/icd/api/binary_cache_serialization.cpp
+++ b/icd/api/binary_cache_serialization.cpp
@@ -54,7 +54,7 @@
 * @brief Implementation of pipeline binary cache serialization in the xgl_cache_support library.
 ***********************************************************************************************************************
 */
-#include "binary_cache_serialization.h"
+#include "include/binary_cache_serialization.h"
 
 #include "palAssert.h"
 #include "palInlineFuncs.h"

--- a/tools/cache_creator/CMakeLists.txt
+++ b/tools/cache_creator/CMakeLists.txt
@@ -35,8 +35,8 @@ include(LLVMConfig)
 
 # Find all the LLVM libraries necessary to use the LLVM components that we use.
 # See https://llvm.org/docs/CMake.html#embedding-llvm-in-your-project.
-llvm_map_components_to_libnames(llvm_libs Support)
-target_link_libraries(cache_creator_lib INTERFACE pal ${llvm_libs})
+llvm_map_components_to_libnames(llvm_libs Object Support)
+target_link_libraries(cache_creator_lib INTERFACE pal xgl_cache_support ${llvm_libs})
 
 target_include_directories(cache_creator_lib INTERFACE
     ${XGL_LLVM_SRC_PATH}/include
@@ -47,8 +47,11 @@ get_target_property(XGL_COMPILE_OPTIONS xgl COMPILE_OPTIONS)
 get_target_property(XGL_COMPILE_DEFINITIONS xgl COMPILE_DEFINITIONS)
 
 # Compile with the same flags and definitions as the ICD and LLVM.
-target_compile_definitions(cache_creator_lib INTERFACE ${LLVM_DEFINITIONS})
-target_compile_definitions(cache_creator_lib INTERFACE ${XGL_COMPILE_DEFINITIONS})
+target_compile_definitions(cache_creator_lib INTERFACE
+    ${LLVM_DEFINITIONS}
+    ${XGL_COMPILE_DEFINITIONS}
+    CC_LLPC_MAJOR_VERSION=${LLPC_MAJOR_VERSION}
+)
 target_compile_options(cache_creator_lib INTERFACE ${XGL_COMPILE_OPTIONS})
 
 target_sources(cache_creator_lib INTERFACE cache_creator.cpp)

--- a/tools/cache_creator/cache_creator.cpp
+++ b/tools/cache_creator/cache_creator.cpp
@@ -1,7 +1,7 @@
 /*
  ***********************************************************************************************************************
  *
- *  Copyright (c) 2020 Google LLC. All Rights Reserved.
+ *  Copyright (c) 2020-2021 Google LLC. All Rights Reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,313 @@
  *
  **********************************************************************************************************************/
 #include "cache_creator.h"
+#include "palPlatformKey.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/raw_ostream.h"
+#include <cassert>
+#include <cinttypes>
+#include <numeric>
+
+#if _POSIX_C_SOURCE >= 200112L
+#include <stdlib.h>
+#endif
 
 namespace cc {
 
-void printNotImplemented() {
-  llvm::errs() << "Cache creator not implemented!\n";
+namespace {
+void *VKAPI_PTR defaultAllocFunc(void *userData, size_t size, size_t alignment, VkSystemAllocationScope allocType) {
+  // On both POSIX and Windows, alignment is required to be a power of 2.
+  // See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc,
+  // and https://linux.die.net/man/3/aligned_alloc.
+  const size_t requiredAlignment = llvm::PowerOf2Ceil(std::max(alignment, sizeof(void *)));
+#if defined(_WIN32)
+  return _aligned_malloc(size, requiredAlignment);
+#elif _POSIX_C_SOURCE >= 200112L
+  void *mem = nullptr;
+  if (posix_memalign(&mem, requiredAlignment, size) != 0)
+    return nullptr;
+  return mem;
+#else
+#error Platform not handled
+#endif
+}
+
+void *VKAPI_PTR defaultReallocFunc(void *userData, void *original, size_t size, size_t alignment,
+                                   VkSystemAllocationScope allocType) {
+  llvm_unreachable("Reallocation not supported"); // See https://github.com/GPUOpen-Drivers/xgl/issues/70.
+}
+
+void VKAPI_PTR defaultFreeFunc(void *userData, void *mem) {
+#if defined(_WIN32)
+  return _aligned_free(mem);
+#elif _POSIX_C_SOURCE >= 200112L
+  free(mem);
+#else
+#error Platform not handled
+#endif
+}
+
+void VKAPI_PTR defaultAllocNotification(void *userData, size_t size, VkInternalAllocationType allocationType,
+                                        VkSystemAllocationScope allocationScope) {
+  // No notification required.
+}
+
+void VKAPI_PTR defaultFreeNotification(void *userData, size_t size, VkInternalAllocationType allocationType,
+                                       VkSystemAllocationScope allocationScope) {
+  // No notification required.
+}
+} // namespace
+
+// =====================================================================================================================
+// Provides the default allocation callbacks, used by XGL code.
+//
+// @returns : Vulkan allocation callbacks
+VkAllocationCallbacks &getDefaultAllocCallbacks() {
+  static VkAllocationCallbacks defaultCallbacks = {
+      nullptr, defaultAllocFunc, defaultReallocFunc, defaultFreeFunc, defaultAllocNotification, defaultFreeNotification,
+  };
+  return defaultCallbacks;
+}
+
+AllocCallbacksDeleter::AllocCallbacksDeleter(VkAllocationCallbacks &callbacks) : m_callbacks(&callbacks) {
+}
+
+void AllocCallbacksDeleter::operator()(void *mem) {
+  m_callbacks->pfnFree(m_callbacks->pUserData, mem);
+}
+
+static bool isValidHexUUIDStr(llvm::StringRef hexStr) {
+  // Sample valid UUID string: 12345678-abcd-ef00-ffff-0123456789ab,
+  // see: https://en.wikipedia.org/wiki/Universally_unique_identifier.
+  static const llvm::Regex uuidRegex("^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$");
+  return hexStr.size() == UuidLength && uuidRegex.match(hexStr);
+}
+
+// =====================================================================================================================
+// Serializes given UUID into a printable string.
+//
+// @param uuid : The input UUID in the binary format
+// @returns : UUID string in the printable format
+UuidString uuidToHexString(llvm::ArrayRef<uint8_t> uuid) {
+  assert(uuid.size() == VK_UUID_SIZE);
+
+  UuidString res;
+  llvm::raw_svector_ostream os(res);
+  for (size_t groupSize : {4, 2, 2, 2, 6}) {
+    os << llvm::format_bytes(uuid.take_front(groupSize), llvm::None,
+                             /* NumPerLine = */ 16, /* BytesPerLine = */ 6);
+    uuid = uuid.drop_front(groupSize);
+    if (!uuid.empty())
+      os << '-';
+  }
+  assert(isValidHexUUIDStr(res));
+  return res;
+}
+
+static uint8_t hexDigitToNum(char c) {
+  assert((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+  return (c >= '0' && c <= '9') ? c - '0' : 10 + (c - 'a');
+}
+
+// =====================================================================================================================
+// Converts a UUID string into its binary representation.
+//
+// @param hexStr : The input hex string in the UUID format
+// @param [out] outUuid : The output buffer where de-serialized UUID gets written to
+// @returns : `true` on success, `false` when the passed `hexStr` is not valid
+bool hexStringToUuid(llvm::StringRef hexStr, llvm::MutableArrayRef<uint8_t> outUuid) {
+  assert(outUuid.size() == VK_UUID_SIZE);
+  if (!isValidHexUUIDStr(hexStr))
+    return false;
+
+  // Go over all hex digits and write out a nibble at a time.
+  // Updates `outUuid` so that the current byte is always at the front.
+  for (auto &&posAndHexDigit : llvm::enumerate(llvm::make_filter_range(hexStr, [](char c) { return c != '-'; }))) {
+    const uint8_t num = hexDigitToNum(posAndHexDigit.value());
+    if (posAndHexDigit.index() % 2 == 0) {
+      outUuid.front() = num << 4;
+    } else {
+      outUuid.front() |= num;
+      outUuid = outUuid.drop_front();
+    }
+  }
+
+  return true;
+}
+
+// =====================================================================================================================
+// Tries to extract cache hash and LLPC version from the elf file.
+//
+// @param elfBuffer : The input elf
+// @returns : The hash found on success, or error on failure
+llvm::Expected<ElfLlpcCacheInfo> getElfLlpcCacheInfo(llvm::MemoryBufferRef elfBuffer) {
+  auto elfObjectOrErr = llvm::object::ELF64LEObjectFile::create(elfBuffer);
+  if (auto err = elfObjectOrErr.takeError())
+    return std::move(err);
+
+  using ElfFileTy = llvm::object::ELF64LEFile;
+  const ElfFileTy &elfFile = elfObjectOrErr->getELFFile();
+
+  auto sectionsOrErr = elfFile.sections();
+  if (auto err = sectionsOrErr.takeError())
+    return std::move(err);
+
+  for (const auto &sectionHeader : *sectionsOrErr) {
+    if (sectionHeader.sh_type != llvm::ELF::SHT_NOTE)
+      continue;
+
+    auto sectionNameOrErr = elfFile.getSectionName(sectionHeader);
+    if (auto err = sectionNameOrErr.takeError()) {
+      llvm::consumeError(std::move(err));
+      continue;
+    }
+    if (!sectionNameOrErr->startswith(".note"))
+      continue;
+
+    llvm::Error notesError(llvm::Error::success());
+    auto noteRange = elfFile.notes(sectionHeader, notesError);
+    if (notesError)
+      return std::move(notesError);
+
+    Util::MetroHash::Hash hash = {};
+    bool foundHash = false;
+    uint32_t llpcVersion[2] = {};
+    bool foundLlpcVersion = false;
+
+    for (const ElfFileTy::Elf_Note &note : noteRange) {
+      llvm::StringRef noteName = note.getName();
+      llvm::ArrayRef<uint8_t> noteBlob = note.getDesc();
+
+      if (noteName.startswith("llpc_cache_hash")) {
+        assert(noteBlob.size() == sizeof(Util::MetroHash::Hash) && "Invalid llpc_cache_hash note");
+        memcpy(hash.bytes, noteBlob.data(), sizeof(hash));
+        foundHash = true;
+      } else if (noteName.startswith("llpc_version")) {
+        assert(noteBlob.size() == sizeof(llpcVersion) && "Invalid llpc_version note");
+        memcpy(llpcVersion, noteBlob.data(), sizeof(llpcVersion));
+        foundLlpcVersion = true;
+      }
+
+      if (foundHash && foundLlpcVersion)
+        return ElfLlpcCacheInfo{hash, llpcVersion[0], llpcVersion[1]};
+    }
+  }
+
+  return llvm::createStringError(llvm::object::object_error::invalid_file_type, "Could not find shader/elf elf hash");
+}
+
+// =====================================================================================================================
+// Computed the total size necessary to serialize a portable PipelineBinaryCache file.
+//
+// @param inputelfSizes : Sizes of input elf files (in bytes)
+// @returns : Total size required to create cache file (in bytes)
+size_t RelocatableCacheCreator::CalculateAnticipatedCacheFileSize(llvm::ArrayRef<size_t> inputElfSizes) {
+  const size_t totalFileContentsSize = std::accumulate(inputElfSizes.begin(), inputElfSizes.end(), 0);
+  const size_t numFiles = inputElfSizes.size();
+  const size_t anticipatedBlobSize =
+      vk::PipelineBinaryCacheSerializer::CalculateAnticipatedCacheBlobSize(numFiles, totalFileContentsSize);
+  return vk::VkPipelineCacheHeaderDataSize + anticipatedBlobSize;
+}
+
+// =====================================================================================================================
+// Initializes a RelocatableCacheCreator object.
+//
+// @param deviceId : The device identifier of the target GPU
+// @param uuid : Pipeline cache UUID in the binary format
+// @param fingerprint : Initial data used to initialize the platform key. This should include information about the
+//                      target GPU and the driver/compiler stack used to construct the cache and later consume it.
+// @param [in/out] outputBuffer : Memory buffer where the pipeline cache data will be written
+// @returns : A RelocatableCacheCreator object on success, error when initialization failures
+llvm::Expected<RelocatableCacheCreator> RelocatableCacheCreator::Create(uint32_t deviceId, llvm::ArrayRef<uint8_t> uuid,
+                                                                        llvm::ArrayRef<uint8_t> fingerprint,
+                                                                        llvm::MutableArrayRef<uint8_t> outputBuffer) {
+  VkAllocationCallbacks &callbacks = cc::getDefaultAllocCallbacks();
+
+  const Util::HashAlgorithm hashAlgo = Util::HashAlgorithm::Sha1;
+  const size_t keyMemSize = Util::GetPlatformKeySize(hashAlgo);
+  void *keyMem = callbacks.pfnAllocation(callbacks.pUserData, keyMemSize, 16, VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
+  assert(keyMem);
+
+  uint8_t *initialData = fingerprint.empty() ? nullptr : const_cast<uint8_t *>(fingerprint.data());
+  Util::IPlatformKey *key = nullptr;
+  if (Util::CreatePlatformKey(hashAlgo, initialData, fingerprint.size(), keyMem, &key) != Util::Result::Success)
+    return llvm::createStringError(std::errc::state_not_recoverable, "Failed to create platform key");
+
+  assert(key);
+  std::unique_ptr<Util::IPlatformKey, AllocCallbacksDeleter> managedKey(key, {callbacks});
+
+  size_t vkHeaderBytes = 0;
+  if (vk::WriteVkPipelineCacheHeaderData(outputBuffer.data(), outputBuffer.size(), cc::AMDVendorId, deviceId,
+                                         const_cast<uint8_t *>(uuid.data()), uuid.size(),
+                                         &vkHeaderBytes) != Util::Result::Success)
+    return llvm::createStringError(std::errc::state_not_recoverable, "Failed to write Vulkan Pipeline Cache header");
+  assert(vkHeaderBytes == vk::VkPipelineCacheHeaderDataSize);
+
+  llvm::MutableArrayRef<uint8_t> privateCacheData = outputBuffer.drop_front(vkHeaderBytes);
+  auto serializer = std::make_unique<vk::PipelineBinaryCacheSerializer>();
+  assert(serializer);
+
+  if (serializer->Initialize(privateCacheData.size(), privateCacheData.data()) != Util::Result::Success)
+    return llvm::createStringError(std::errc::state_not_recoverable,
+                                   "Failed to initialize PipelineBinaryCacheSerializer");
+
+  return RelocatableCacheCreator(std::move(managedKey), std::move(serializer), outputBuffer, callbacks);
+}
+
+// =====================================================================================================================
+// Adds a new cache entry with the provided elf file.
+//
+// @param elfBuffer : Buffer with a relocatable shader elf compiled with LLPC
+// @returns : Error if it's not possible to process the elf or append it to the output buffer, or success
+llvm::Error RelocatableCacheCreator::addElf(llvm::MemoryBufferRef elfBuffer) {
+  auto elfLlpcInfoOrErr = cc::getElfLlpcCacheInfo(elfBuffer);
+  if (auto err = elfLlpcInfoOrErr.takeError())
+    return llvm::createFileError(elfBuffer.getBufferIdentifier(), std::move(err));
+
+  vk::BinaryCacheEntry entry = {};
+  entry.dataSize = elfBuffer.getBufferSize();
+  entry.hashId = elfLlpcInfoOrErr->cacheHash;
+
+  // TODO(kuhar): Also check if the LLPC minor version from the elf matches the current LLPC version from the build.
+  // LLPC minor version is not currently available to this targer, so we need to update CMake to access it here.
+  if (elfLlpcInfoOrErr->llpcMajorVersion != BuildLlpcMajorVersion)
+    return llvm::createFileError(elfBuffer.getBufferIdentifier(),
+                                 llvm::createStringError(std::errc::state_not_recoverable,
+                                                         "Elf LLPC version (% " PRIu32
+                                                         ")  not compatible with the tool LLPC version (%" PRIu32 ")",
+                                                         elfLlpcInfoOrErr->llpcMajorVersion, BuildLlpcMajorVersion));
+
+  if (m_serializer->AddPipelineBinary(&entry, elfBuffer.getBufferStart()) != Util::Result::Success)
+    return llvm::createFileError(
+        elfBuffer.getBufferIdentifier(),
+        llvm::createStringError(std::errc::state_not_recoverable, "Failed to add cache entry"));
+
+  return llvm::Error::success();
+}
+
+// =====================================================================================================================
+// Finalizes the cache file and writes remaining validation data.
+//
+// @param [out] outTotalNumEntries : (Optional) Variable to store the total number of cache entries added
+// @param [out] outTotalSize: (Optional) Variable to store the final cache blob size
+// @returns : Error if it's not possible to finish cache serialization, or success.
+llvm::Error RelocatableCacheCreator::finalize(size_t *outTotalNumEntries, size_t *outTotalSize) {
+  size_t actualNumEntries = 0;
+  size_t actualCacheSize = 0;
+  if (m_serializer->Finalize(m_callbacks, m_platformKey.get(), &actualNumEntries, &actualCacheSize) !=
+      Util::Result::Success)
+    return llvm::createStringError(std::errc::state_not_recoverable, "Failed to serialize cache");
+
+  if (outTotalNumEntries)
+    *outTotalNumEntries = actualNumEntries;
+  if (outTotalSize)
+    *outTotalSize = actualCacheSize + vk::VkPipelineCacheHeaderDataSize;
+
+  return llvm::Error::success();
 }
 
 } // namespace cc

--- a/tools/cache_creator/cache_creator.h
+++ b/tools/cache_creator/cache_creator.h
@@ -1,7 +1,7 @@
 /*
  ***********************************************************************************************************************
  *
- *  Copyright (c) 2020 Google LLC. All Rights Reserved.
+ *  Copyright (c) 2020-2021 Google LLC. All Rights Reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,86 @@
  **********************************************************************************************************************/
 #pragma once
 
+#include "util/palMetroHash.h"
+#include "include/binary_cache_serialization.h"
+
+// These Xlib defines conflict with LLVM.
+#undef Bool
+#undef Status
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBufferRef.h"
+
 namespace cc {
 
-void printNotImplemented();
+constexpr uint32_t AMDVendorId = 0x1002; // See https://pci-ids.ucw.cz/read/PC/1002.
+
+// The LLPC version number in the current source tree.
+constexpr uint32_t BuildLlpcMajorVersion = CC_LLPC_MAJOR_VERSION;
+
+VkAllocationCallbacks &getDefaultAllocCallbacks();
+
+// Deleter class that enables PAL/XGL types allocated with VkAllocationCallbacks to be used with std::unique_ptr.
+// This deleter calles the free function from the given callback, instead of using a plain `delete` operator.
+struct AllocCallbacksDeleter {
+  AllocCallbacksDeleter(VkAllocationCallbacks &callbacks);
+  void operator()(void *mem);
+
+private:
+  VkAllocationCallbacks *m_callbacks;
+};
+
+constexpr size_t UuidLength = 36;
+using UuidString = llvm::SmallString<UuidLength>;
+
+// Serializes given UUID into a printable string.
+UuidString uuidToHexString(llvm::ArrayRef<uint8_t> uuid);
+
+// Converts a UUID string into its binary representation.
+bool hexStringToUuid(llvm::StringRef hexStr, llvm::MutableArrayRef<uint8_t> outUuid);
+
+struct ElfLlpcCacheInfo {
+  Util::MetroHash::Hash cacheHash;
+  uint32_t llpcMajorVersion;
+  uint32_t llpcMinorVersion;
+};
+
+// Tries to extract cache hash and LLPC version from the elf file.
+llvm::Expected<ElfLlpcCacheInfo> getElfLlpcCacheInfo(llvm::MemoryBufferRef elfBuffer);
+
+// Creates portable PipelineBinaryCache files from relocatable LLPC elf files.
+// This class is moveable but not copyable.
+class RelocatableCacheCreator {
+public:
+  static size_t CalculateAnticipatedCacheFileSize(llvm::ArrayRef<size_t> inputElfSizes);
+  static llvm::Expected<RelocatableCacheCreator> Create(uint32_t deviceId, llvm::ArrayRef<uint8_t> uuid,
+                                                        llvm::ArrayRef<uint8_t> fingerprint,
+                                                        llvm::MutableArrayRef<uint8_t> outputBuffer);
+
+  RelocatableCacheCreator() = delete;
+  RelocatableCacheCreator(const RelocatableCacheCreator &) = delete;
+  RelocatableCacheCreator &operator=(const RelocatableCacheCreator &) = delete;
+
+  RelocatableCacheCreator(RelocatableCacheCreator &&) = default;
+  RelocatableCacheCreator &operator=(RelocatableCacheCreator &&) = default;
+
+  llvm::Error addElf(llvm::MemoryBufferRef elfBuffer);
+  llvm::Error finalize(size_t *outTotalNumEntries, size_t *outTotalSize);
+
+private:
+  RelocatableCacheCreator(std::unique_ptr<Util::IPlatformKey, AllocCallbacksDeleter> platformKey,
+                          std::unique_ptr<vk::PipelineBinaryCacheSerializer> serializer,
+                          llvm::MutableArrayRef<uint8_t> outputBuffer, VkAllocationCallbacks &callbacks)
+      : m_platformKey(std::move(platformKey)), m_serializer(std::move(serializer)), m_outputBuffer(outputBuffer),
+        m_callbacks(&callbacks) {}
+
+  std::unique_ptr<Util::IPlatformKey, AllocCallbacksDeleter> m_platformKey;
+  std::unique_ptr<vk::PipelineBinaryCacheSerializer> m_serializer;
+  llvm::MutableArrayRef<uint8_t> m_outputBuffer;
+  VkAllocationCallbacks *m_callbacks;
+};
 
 } // namespace cc

--- a/tools/cache_creator/cache_creator_main.cpp
+++ b/tools/cache_creator/cache_creator_main.cpp
@@ -1,7 +1,7 @@
 /*
  ***********************************************************************************************************************
  *
- *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *  Copyright (c) 2020-2021 Google LLC. All Rights Reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -23,40 +23,127 @@
  *
  **********************************************************************************************************************/
 #include "cache_creator.h"
-#include "palPlatformKey.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileOutputBuffer.h"
+#include "llvm/Support/FileSystem.h"
 #include <cassert>
-#include <string>
 
 namespace {
 llvm::cl::OptionCategory CacheCreatorCat("Cache Creator Options");
 
 llvm::cl::list<std::string> InFiles(llvm::cl::Positional, llvm::cl::OneOrMore, llvm::cl::ValueRequired,
                                     llvm::cl::cat(CacheCreatorCat), llvm::cl::desc("<Input elf file(s)>"));
-llvm::cl::opt<std::string> OutFileName("o", llvm::cl::desc("Output filename"), llvm::cl::cat(CacheCreatorCat),
-                                       llvm::cl::value_desc("filename"), llvm::cl::Required);
-llvm::cl::opt<std::string> DeviceIdStr("device-id", llvm::cl::desc("Device ID"), llvm::cl::cat(CacheCreatorCat));
-llvm::cl::opt<std::string> UUIDStr("uuid", llvm::cl::desc("UUID for the specific driver and machine"),
-                                   llvm::cl::cat(CacheCreatorCat));
+llvm::cl::opt<std::string> OutFileName("o", llvm::cl::desc("Output cache file"), llvm::cl::cat(CacheCreatorCat),
+                                       llvm::cl::value_desc("filename.bin"), llvm::cl::Required);
+llvm::cl::opt<uint32_t> DeviceId("device-id", llvm::cl::desc("Devide ID. This must match the target GPU."),
+                                 llvm::cl::value_desc("number"), llvm::cl::cat(CacheCreatorCat), llvm::cl::Required);
+
+// This UUID is generated in vk_physical_device.cpp::Initialize.
+llvm::cl::opt<std::string>
+    UuidStr("uuid",
+            llvm::cl::desc(
+                "Pipeline cache UUID for the specific driver and machine, e.g., 00000000-12345-6789-abcd-ef0000000042"),
+            llvm::cl::value_desc("hex string"), llvm::cl::cat(CacheCreatorCat), llvm::cl::Required);
+
+llvm::cl::opt<bool> Verbose("verbose", llvm::cl::desc("Enable verbose output"), llvm::cl::init(false),
+                            llvm::cl::cat(CacheCreatorCat));
+
+// =====================================================================================================================
+// Returns an ostream for printing output info messages.
+//
+// @returns : Output stream writing to STDOUT if `--verbose` is enabled, or a stream that doesn't print anything if not
+llvm::raw_ostream &infos() {
+  if (Verbose)
+    return llvm::outs();
+
+  static llvm::raw_null_ostream blackHole;
+  return blackHole;
+}
 } // namespace
 
-int main(int argc, char **argv) {
-  for (auto &strOptionPair : llvm::cl::getRegisteredOptions()) {
-    auto *opt = strOptionPair.second;
+namespace fs = llvm::sys::fs;
 
-    if (opt && llvm::none_of(opt->Categories, [](const llvm::cl::OptionCategory *category) {
-          return category && (category == &CacheCreatorCat || category->getName() == "Generic Options");
-        })) {
-      opt->setHiddenFlag(llvm::cl::Hidden);
-    }
+static llvm::Error getFileSizes(llvm::ArrayRef<std::string> filenames, llvm::MutableArrayRef<size_t> outFileSizes) {
+  assert(filenames.size() == outFileSizes.size());
+  for (auto &&nameSizePair : llvm::zip(filenames, outFileSizes)) {
+    const std::string &filename = std::get<0>(nameSizePair);
+    if (std::error_code err = fs::file_size(filename, std::get<1>(nameSizePair)))
+      return llvm::createFileError(filename, llvm::createStringError(err, "Failed to read file size"));
   }
+  return llvm::Error::success();
+}
+
+int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
-  Util::IPlatformKey *key = nullptr;
-  (void)key;
+  llvm::outs() << "NOTE: cache-creator is still under development. Things may not work as expected.\n\n";
 
-  cc::printNotImplemented();
-  assert(false && "Not implemented");
-  return 1;
+  std::array<uint8_t, VK_UUID_SIZE> uuid = {};
+  if (!cc::hexStringToUuid(UuidStr, uuid)) {
+    llvm::errs() << "Failed to parse pipeline cache UUID (--uuid). See `cache-creator --help` for usage details.\n";
+    return 2;
+  }
+
+  const size_t numFiles = InFiles.size();
+  llvm::SmallVector<size_t> fileSizes(numFiles);
+  if (auto err = getFileSizes(InFiles, fileSizes)) {
+    llvm::errs() << err << "\n";
+    llvm::consumeError(std::move(err));
+    return 3;
+  }
+
+  const size_t cacheBlobSize = cc::RelocatableCacheCreator::CalculateAnticipatedCacheFileSize(fileSizes);
+  infos() << "Num inputs: " << numFiles << ", anticipated cache size: " << cacheBlobSize << "\n";
+
+  auto outFileBufferOrErr = llvm::FileOutputBuffer::create(OutFileName, cacheBlobSize);
+  if (auto err = outFileBufferOrErr.takeError()) {
+    llvm::errs() << "Failed to create the output file " << OutFileName << ". Error:\t" << err << "\n";
+    llvm::consumeError(std::move(err));
+    return 4;
+  }
+
+  // TODO(kuhar): Initialize the platform key properly by providing the `fingerprint` parameter instead of an empty
+  // array. This is so that the cache can pass validation and be consumed by the ICD. Note that this also requires
+  // ICD-side changes.
+  auto cacheCreatorOrErr = cc::RelocatableCacheCreator::Create(
+      DeviceId, uuid, {},
+      llvm::makeMutableArrayRef((*outFileBufferOrErr)->getBufferStart(), (*outFileBufferOrErr)->getBufferSize()));
+  if (auto err = cacheCreatorOrErr.takeError()) {
+    llvm::errs() << "Error:\t" << err << "\n";
+    llvm::consumeError(std::move(err));
+    return 4;
+  }
+  cc::RelocatableCacheCreator &cacheCreator = *cacheCreatorOrErr;
+
+  for (const std::string &filename : InFiles) {
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> inputBufferOrErr = llvm::MemoryBuffer::getFile(filename);
+    if (std::error_code err = inputBufferOrErr.getError()) {
+      llvm::errs() << "Failed to read input file " << filename << ": " << err.message() << "\n";
+      return 3;
+    }
+    infos() << "Read: " << filename << "\n";
+
+    if (auto err = cacheCreator.addElf(**inputBufferOrErr)) {
+      llvm::errs() << "Error:\t" << err << "\n";
+      llvm::consumeError(std::move(err));
+      return 4;
+    }
+  }
+
+  size_t actualNumEntries = 0;
+  size_t actualCacheSize = 0;
+  if (auto err = cacheCreator.finalize(&actualNumEntries, &actualCacheSize)) {
+    llvm::errs() << "Error:\t" << err << "\n";
+    llvm::consumeError(std::move(err));
+    return 4;
+  }
+  infos() << "Num entries written: " << actualNumEntries << ", actual cache size: " << actualCacheSize << " B\n";
+
+  if ((*outFileBufferOrErr)->commit()) {
+    llvm::errs() << "Failed to commit the serialized cache to the output file\n";
+    return 4;
+  }
+  llvm::outs() << "Cache successfully written to: " << (*outFileBufferOrErr)->getPath() << "\n";
+
+  return 0;
 }


### PR DESCRIPTION
This implementation can bundle relocatable elf files, read llpc
cache hashes from elf notes, and output cache in the pipeline binary
cache file format. The produced cache files cannot be consumed by the
ICD yet.

Tests will be submitted in a separate Pull Request to minimize the scope
of this PR. They require further build system tweaks.