### PR TITLE
[CI] Add GitHub Actions checks for cache creator

### DIFF
--- a/.github/workflows/check-formatting-cache-creator.yml
+++ b/.github/workflows/check-formatting-cache-creator.yml
@@ -1,0 +1,40 @@
+name: Cache Creator code formatting
+
+on:
+  pull_request:
+
+jobs:
+  clang-format-check:
+    name: clang-format
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get install -yqq clang-format-10
+      - name: Checkout XGL
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY}.git .
+          git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
+          git checkout ${GITHUB_SHA}
+      - name: Run clang-format
+        working-directory: ./tools/cache_creator
+        run: |
+          git diff ${{ github.base_ref }} -U0 --no-color -- '**/*.cpp' '**/*.cc' '**/*.h' '**/*.hh' \
+            | clang-format-diff-10 -p1 >not-formatted.diff 2>&1
+      - name: Check formatting
+        working-directory: ./tools/cache_creator
+        run: |
+          if ! grep -q '[^[:space:]]' not-formatted.diff ; then
+            echo "Code formatted. Success."
+          else
+            echo "Code not formatted."
+            echo "Please run clang-format-diff on your changes and push again:"
+            echo "    git diff ${{ github.base_ref }} -U0 --no-color | clang-format-diff -p1 -i"
+            echo ""
+            echo "Tip: you can disable clang-format checks: https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code"
+            echo ""
+            echo "Diff:"
+            cat not-formatted.diff
+            echo ""
+            exit 3
+          fi

--- a/.github/workflows/check-xgl-docker.yml
+++ b/.github/workflows/check-xgl-docker.yml
@@ -1,0 +1,43 @@
+name: Check XGL
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: "Features: ${{ matrix.feature-set }}, assertions: ${{ matrix.assertions }}"
+    runs-on: ${{ matrix.host-os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host-os:             ["ubuntu-20.04"]
+        base-image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]
+        config:              [Release]
+        assertions:          ["OFF", "ON"]
+        feature-set:         ["+gcc", "+clang"]
+    steps:
+      - name: Checkout XGL
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY}.git .
+          git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
+          git checkout ${GITHUB_SHA}
+      - name: Generate Docker base image tag string
+        run: |
+          CONFIG_LOWER=$(echo "${{ matrix.config }}" | tr "[:upper:]" "[:lower:]")
+          FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
+          ASSERTS_LOWER=$(echo "${{ matrix.assertions }}" | tr "[:upper:]" "[:lower:]")
+          TAG=$(printf "${{ matrix.base-image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER" "$ASSERTS_LOWER")
+          echo "IMAGE_TAG=$TAG" | tee -a $GITHUB_ENV
+      - name: Fetch the latest prebuilt AMDVLK
+        run: docker pull "$IMAGE_TAG"
+      - name: Build and Test with Docker
+        run: docker build . --file tools/cache_creator/docker/check_xgl.Dockerfile
+                            --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
+                            --build-arg XGL_REPO_NAME="${GITHUB_REPOSITORY}"
+                            --build-arg XGL_REPO_REF="${GITHUB_REF}"
+                            --build-arg XGL_REPO_SHA="${GITHUB_SHA}"
+                            --tag xgl/xgl-ci

--- a/tools/cache_creator/docker/check_xgl.Dockerfile
+++ b/tools/cache_creator/docker/check_xgl.Dockerfile
@@ -1,0 +1,42 @@
+#
+# Dockerfile for public XGL CI with GitHub Actions.
+# Sample invocation:
+#    docker build . --file tools/cache_creator/docker/check_xgl.Dockerfile                    \
+#                   --build-arg AMDVLK_IMAGE=gcr.io/stadia-open-source/amdvlk:nightly         \
+#                   --build-arg XGL_REPO_NAME=GPUOpen-Drivers/xgl                             \
+#                   --build-arg XGL_REPO_REF=<GIT_REF>                                        \
+#                   --build-arg XGL_REPO_SHA=<GIT_SHA>                                        \
+#                   --tag xgl-ci/xgl
+#
+# Required arguments:
+# - AMDVLK_IMAGE: Base image name for prebuilt amdvlk
+# - XGL_REPO_NAME: Name of the xgl repository to clone
+# - XGL_REPO_REF: ref name to checkout
+# - XGL_REPO_SHA: SHA of the commit to checkout
+#
+
+# Resume build from the specified image.
+ARG AMDVLK_IMAGE
+FROM "$AMDVLK_IMAGE"
+
+ARG XGL_REPO_NAME
+ARG XGL_REPO_REF
+ARG XGL_REPO_SHA
+
+# Use bash instead of sh in this docker file.
+SHELL ["/bin/bash", "-c"]
+
+# Sync the repos. Replace the base LLPC with a freshly checked-out one.
+RUN cat /vulkandriver/build_info.txt \
+    && (cd /vulkandriver && repo sync -c --no-clone-bundle -j$(nproc)) \
+    && git -C /vulkandriver/drivers/xgl remote add origin https://github.com/"$XGL_REPO_NAME".git \
+    && git -C /vulkandriver/drivers/xgl fetch origin +"$XGL_REPO_SHA":"$XGL_REPO_REF" --update-head-ok \
+    && git -C /vulkandriver/drivers/xgl checkout "$XGL_REPO_SHA"
+
+# Build XGL targets.
+WORKDIR /vulkandriver/builds/ci-build
+RUN source /vulkandriver/env.sh \
+    && cmake --build . \
+    && cmake --build . --target amdvlk64.so cache-creator
+
+# TODO: Run the cache-creator test suites when they get merged


### PR DESCRIPTION
Add a workflow that builds the ICD and the cache-creator to make
sure they build with both gcc and clang, with and without assertions.
This workflow uses the nightly docker images created by the LLPC cron
job:
https://github.com/GPUOpen-Drivers/llpc/actions?query=workflow%3A%22Build+AMDVLK+for+LLPC%22
to speed up the builds.

Add a workflow that ensures cache creator sources are properly
formatted.

This is mostly based on the public CI for LLPC:
https://github.com/GPUOpen-Drivers/llpc/actions.