### PR TITLE
Add initial LIT tests configuration

### DIFF
--- a/tools/cache_creator/CMakeLists.txt
+++ b/tools/cache_creator/CMakeLists.txt
@@ -65,3 +65,9 @@ target_link_libraries(cache-creator PRIVATE cache_creator_lib)
 add_dependencies(xgl cache-creator)
 
 # TODO: Add unit tests.
+
+if(XGL_BUILD_LIT)
+    message(STATUS "Building cache creator LIT tests")
+    set(CACHE_CREATOR_TOOLS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    add_subdirectory(test "${CMAKE_CURRENT_BINARY_DIR}/test/cache-creator")
+endif()

--- a/tools/cache_creator/test/CMakeLists.txt
+++ b/tools/cache_creator/test/CMakeLists.txt
@@ -1,0 +1,50 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+# Set up the LIT testing environment. See https://llvm.org/docs/CommandGuide/lit.html.
+
+# These constants are used to fill in lit.site.cfg.py.in and propagate the project configuration to LIT.
+set(CACHE_CREATOR_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(CACHE_CREATOR_TEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(CACHE_CREATOR_AMDLLPC_DIR ${LLPC_BINARY_DIR})
+set(CACHE_CREATOR_DEFAULT_GFXIP "9")
+
+# TODO: SPVGEN binary dir should be propagated from LLPC to its parent scope (XGL) and used here.
+set(CACHE_CREATOR_SPVGEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../spvgen)
+
+# Required by configure_lit_site_cfg; this allows it to find the llvm-lit executable.
+set(LLVM_LIT_OUTPUT_DIR ${LLVM_TOOLS_BINARY_DIR})
+configure_lit_site_cfg(
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+    MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+)
+
+# You can execute test by building the `check-cache-creator` target, e.g., `ninja check-cache-creator`.
+add_lit_testsuite(check-cache-creator "Running the XGL cache creator regression tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS cache-creator amdllpc spvgen FileCheck count not
+)

--- a/tools/cache_creator/test/RunLitCommands.spvasm
+++ b/tools/cache_creator/test/RunLitCommands.spvasm
@@ -1,0 +1,41 @@
+; Check if lit is configured properly and that all basic tools run.
+; RUN: amdllpc %s %gfxip %spvgen %reloc -v -o %t.elf | FileCheck --check-prefix=CHECK-LLPC %s
+; CHECK-LLPC: {{^// LLPC}} SPIRV-to-LLVM translation results
+; CHECK-LLPC: AMDLLPC SUCCESS
+
+; RUN: cache-creator --help | FileCheck -check-prefix=CHECK-CC %s
+; CHECK-CC: Cache Creator Options
+
+; RUN: llvm-objdump --version | FileCheck -check-prefix=CHECK-OBJDUMP %s
+; CHECK-OBJDUMP: Registered Targets
+
+; RUN: llvm-readelf --version | FileCheck -check-prefix=CHECK-READELF %s
+; CHECK-READELF: Registered Targets
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 12
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %fragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 460
+               OpName %main "main"
+               OpName %fragColor "fragColor"
+               OpDecorate %fragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %fragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+         %11 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %fragColor %11
+               OpReturn
+               OpFunctionEnd

--- a/tools/cache_creator/test/lit.cfg.py
+++ b/tools/cache_creator/test/lit.cfg.py
@@ -1,0 +1,61 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+import lit.util
+import lit.formats
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import FindTool
+from lit.llvm.subst import ToolSubst
+
+# name: The name of this test suite.
+config.name = 'cache creator'
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files. This is overridden
+# by individual lit.local.cfg files in the test subdirectories.
+config.suffixes = ['.spvasm', '.pipe']
+
+# excludes: A list of directories to exclude from the testsuite.
+config.excludes = []
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.test_run_dir, 'test_output')
+
+llvm_config.use_default_substitutions()
+
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+config.substitutions.append(('%gfxip', '-gfxip=' + config.gfxip))
+config.substitutions.append(('%spvgen', '-spvgen-dir=' + config.spvgen_dir))
+config.substitutions.append(('%reloc', '-unlinked -enable-relocatable-shader-elf'))
+
+tool_dirs = [config.cache_creator_tools_dir, config.amdllpc_dir, config.llvm_tools_dir]
+tools = ['amdllpc', 'cache-creator', 'llvm-objdump', 'llvm-readelf', 'count', 'not']
+llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/tools/cache_creator/test/lit.site.cfg.py.in
+++ b/tools/cache_creator/test/lit.site.cfg.py.in
@@ -1,0 +1,32 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.lit_tools_dir = "@LLVM_TOOLS_DIR@"
+config.python_executable = "@PYTHON_EXECUTABLE@"
+
+config.llvm_assertions = "@LLVM_ENABLE_ASSERTIONS@"
+
+config.cache_creator_tools_dir = "@CACHE_CREATOR_TOOLS_BINARY_DIR@"
+config.amdllpc_dir = "@CACHE_CREATOR_AMDLLPC_DIR@"
+config.gfxip = "@CACHE_CREATOR_DEFAULT_GFXIP@"
+config.spvgen_dir = "@CACHE_CREATOR_SPVGEN_DIR@"
+config.test_run_dir = "@CACHE_CREATOR_TEST_BINARY_DIR@"
+
+# Support substitution of the tools_dir with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@CACHE_CREATOR_TEST_SOURCE_DIR@/lit.cfg.py")


### PR DESCRIPTION
Allow to add future regression tests.
Add a test that ensures that all tools are available and can be executed.