### PR TITLE
Allow to disable internal on-disk pipeline caching

### DIFF
--- a/icd/api/include/pipeline_binary_cache.h
+++ b/icd/api/include/pipeline_binary_cache.h
@@ -68,7 +68,7 @@ public:
 #endif
         size_t                     initDataSize,
         const void*                pInitData,
-        bool                       internal);
+        bool                       createArchiveLayers);
 
     static bool IsValidBlob(
         VkAllocationCallbacks* pAllocationCallbacks,
@@ -80,6 +80,7 @@ public:
 
     VkResult Initialize(
         const RuntimeSettings&    settings,
+        bool                      createArchiveLayers,
         const char*               pDefaultCacheFilePath,
         const Util::IPlatformKey* pKey);
 
@@ -172,8 +173,7 @@ private:
 
     explicit PipelineBinaryCache(
         VkAllocationCallbacks*    pAllocationCallbacks,
-        const Vkgc::GfxIpVersion& gfxIp,
-        bool                      internal);
+        const Vkgc::GfxIpVersion& gfxIp);
 
     VkResult InitializePlatformKey(
         const PhysicalDevice*  pPhysicalDevice,
@@ -188,7 +188,7 @@ private:
 
     VkResult InitLayers(
         const char*            pDefaultCacheFilePath,
-        bool                   internal,
+        bool                   createArchiveLayers,
         const RuntimeSettings& settings);
 
 #if ICD_GPUOPEN_DEVMODE_BUILD
@@ -249,8 +249,6 @@ private:
     Util::ICacheLayer*  m_pArchiveLayer;  // Top of a chain of loaded archives.
     FileVector          m_openFiles;
     LayerVector         m_archiveLayers;
-
-    bool                m_isInternalCache;
 
     CacheAdapter*       m_pCacheAdapter;
 

--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -175,14 +175,14 @@ VkResult PipelineCompiler::Initialize()
                 m_pPhysicalDevice->VkInstance()->GetAllocCallbacks(),
                 m_pPhysicalDevice->GetPlatformKey(),
                 m_gfxIp,
-                m_pPhysicalDevice->GetRuntimeSettings(),
+                settings,
                 m_pPhysicalDevice->PalDevice()->GetCacheFilePath(),
 #if ICD_GPUOPEN_DEVMODE_BUILD
                 m_pPhysicalDevice->VkInstance()->GetDevModeMgr(),
 #endif
                 0,
                 nullptr,
-                true);
+                settings.enableOnDiskInternalPipelineCaches);
 
         // This isn't a terminal failure, the device can continue without the pipeline cache if need be.
         VK_ALERT(m_pBinaryCache == nullptr);

--- a/icd/settings/settings_xgl.json
+++ b/icd/settings/settings_xgl.json
@@ -1866,7 +1866,7 @@
     },
     {
       "Name": "AllowVkPipelineCachingToDisk",
-      "Description": "Controls whether the pipeline compiler enables Pal's archive-file based caching for saving shader ELFs. (Default: TRUE) Related environment variables AMD_ARCHIVE_DISK_CACHE_PATH: Path to where archive file is to be stored (optional) AMD_ARCHIVE_APP_PREFIX     : Fixed prefix string for generated archive file name (optional)",
+      "Description": "Controls whether the pipeline compiler enables internal pipeline caching. This also allows the Vulkan application to get a Vulkan Pipeline Cache object based on internal caches, without creating an application-managed Vulkan Pipeline Cache. (Default: TRUE) Related environment variables AMD_ARCHIVE_DISK_CACHE_PATH: Path to where archive file is to be stored (optional) AMD_ARCHIVE_APP_PREFIX     : Fixed prefix string for generated archive file name (optional)",
       "Tags": [
         "SPIRV Options"
       ],
@@ -1877,6 +1877,19 @@
       },
       "Type": "bool",
       "VariableName": "usePalPipelineCaching",
+      "Scope": "Driver"
+    },
+    {
+      "Name": "EnableInternalPipelineCachingToDisk",
+      "Description": "Controls whether the pipeline compiler enables Pal's archive-file based caching for internal pipelines. (Default: TRUE) Related environment variables AMD_ARCHIVE_DISK_CACHE_PATH: Path to where archive file is to be stored (optional) AMD_ARCHIVE_APP_PREFIX     : Fixed prefix string for generated archive file name (optional)",
+      "Tags": [
+        "SPIRV Options"
+      ],
+      "Defaults": {
+        "Default": true
+      },
+      "Type": "bool",
+      "VariableName": "enableOnDiskInternalPipelineCaches",
       "Scope": "Driver"
     },
     {


### PR DESCRIPTION
Add a new panel setting, `EnableInternalPipelineCachingToDisk` that
controlls whether the ICD will write out its internal pipeline caches to
disk.

Note that this sounds similar to the existing setting
`AllowVkPipelineCachingToDisk`, but the key difference is that this
existing one controlls whether an internal cache based on PBC will be
created at all, while the new setting from this PR allows for internal
PBC caches that are not backed by archive files.