### PR TITLE
[WiP] Add portable pipeline cache blob format support

### DIFF
--- a/icd/api/binary_cache_serialization.cpp
+++ b/icd/api/binary_cache_serialization.cpp
@@ -156,13 +156,14 @@ Util::Result CalculatePipelineBinaryCacheHashId(
 // Returns Util::Result::Success on success or Util::Result::ErrorInvalidMemorySize if the provided buffer is too small
 // to create a valid pipeline binary cache blob.
 Util::Result PipelineBinaryCacheSerializer::Initialize(
+    PipelineCacheBlobFormat blobFormat,
     size_t bufferCapacity,
     void*  pOutputBuffer)
 {
     PAL_ASSERT(pOutputBuffer != nullptr);
 
     Util::Result result = Util::Result::ErrorInvalidMemorySize;
-
+    m_blobFormat = blobFormat;
     m_pOutputBuffer = pOutputBuffer;
     if (bufferCapacity >= HeaderSize)
     {
@@ -223,6 +224,7 @@ Util::Result PipelineBinaryCacheSerializer::Finalize(
         *pBytesWritten = m_bytesUsed;
     }
 
+    pPrivateHeader->blobFormat = m_blobFormat;
     return CalculatePipelineBinaryCacheHashId(pAllocationCallbacks,
                                               pKey,
                                               pCacheDataBegin,

--- a/icd/api/include/binary_cache_serialization.h
+++ b/icd/api/include/binary_cache_serialization.h
@@ -103,10 +103,16 @@ struct BinaryCacheEntry
     size_t                dataSize;
 };
 
+enum class PipelineCacheBlobFormat : uint32_t {
+    Strict = 0,
+    Portable = 1
+};
+
 // Layout for pipeline binary cache header, all fields are written with LSB first.
 constexpr size_t SHA_DIGEST_LENGTH = 20;
 struct PipelineBinaryCachePrivateHeader
 {
+    PipelineCacheBlobFormat blobFormat;
     uint8_t  hashId[SHA_DIGEST_LENGTH];
 };
 
@@ -135,8 +141,9 @@ public:
     PipelineBinaryCacheSerializer() = default;
 
     Util::Result Initialize(
-        size_t bufferCapacity,
-        void*  pOutputBuffer);
+        PipelineCacheBlobFormat blobFormat,
+        size_t                  bufferCapacity,
+        void*                   pOutputBuffer);
 
     Util::Result AddPipelineBinary(
         const BinaryCacheEntry* pEntry,
@@ -151,13 +158,14 @@ public:
 private:
     PAL_DISALLOW_COPY_AND_ASSIGN(PipelineBinaryCacheSerializer);
 
-    static constexpr size_t HeaderSize      = sizeof(PipelineBinaryCachePrivateHeader);
-    static constexpr size_t EntryHeaderSize = sizeof(BinaryCacheEntry);
+    static constexpr size_t HeaderSize       = sizeof(PipelineBinaryCachePrivateHeader);
+    static constexpr size_t EntryHeaderSize  = sizeof(BinaryCacheEntry);
 
-    size_t m_numEntries     = 0;
-    void*  m_pOutputBuffer  = nullptr;
-    size_t m_bufferCapacity = 0;
-    size_t m_bytesUsed      = 0;
+    PipelineCacheBlobFormat m_blobFormat     = {};
+    size_t                  m_numEntries     = 0;
+    void*                   m_pOutputBuffer  = nullptr;
+    size_t                  m_bufferCapacity = 0;
+    size_t                  m_bytesUsed      = 0;
 };
 
 }

--- a/icd/api/include/pipeline_binary_cache.h
+++ b/icd/api/include/pipeline_binary_cache.h
@@ -35,6 +35,7 @@
 #include "palMetroHash.h"
 #include "palVector.h"
 #include "palCacheLayer.h"
+#include "binary_cache_serialization.h"
 #include "cache_adapter.h"
 
 namespace Util
@@ -48,8 +49,6 @@ class DevModeMgr;
 
 namespace vk
 {
-
-class CacheAdapter;
 
 // Unified pipeline cache interface
 class PipelineBinaryCache
@@ -71,10 +70,11 @@ public:
         bool                       createArchiveLayers);
 
     static bool IsValidBlob(
-        VkAllocationCallbacks* pAllocationCallbacks,
-        Util::IPlatformKey*    pKey,
-        size_t                 dataSize,
-        const void*            pData);
+        VkAllocationCallbacks*  pAllocationCallbacks,
+        Util::IPlatformKey*     pKey,
+        PipelineCacheBlobFormat expectedCacheBlobFormat,
+        size_t                  dataSize,
+        const void*             pData);
 
     ~PipelineBinaryCache();
 
@@ -120,8 +120,9 @@ public:
         const Util::QueryResult* pQuery) const;
 
     VkResult Serialize(
-        void*   pBlob,
-        size_t* pSize);
+        void*                   pBlob,
+        size_t*                 pSize,
+        PipelineCacheBlobFormat cacheBlobFormat);
 
     VkResult Merge(
         uint32_t                    srcCacheCount,

--- a/icd/settings/settings_xgl.json
+++ b/icd/settings/settings_xgl.json
@@ -2000,7 +2000,7 @@
       "Scope": "Driver",
       "Type": "uint64"
     },
-    {
+     {
       "Name": "MarkPipelineCacheWithBuildTimestamp",
       "Description": "Controles whether the pipline cache is tagged with the build timestamp. This provides extra stability by forcing a cache rebuild for every new driver released.  May be useful to disable during rapid iteration. (Default: TRUE)",
       "Tags": [
@@ -2008,6 +2008,18 @@
       ],
       "Defaults": {
         "Default": true
+      },
+      "Scope": "Driver",
+      "Type": "bool"
+    },
+    {
+      "Name": "EnablePortablePipelineCacheFormat",
+      "Description": "Controles whether the pipline binary cache use the portable format. This makes pipeline caches portable across machines. This is an experimental option not meant for general use. (Default: FALSE)",
+      "Tags": [
+        "SPIRV Options"
+      ],
+      "Defaults": {
+        "Default": false
       },
       "Scope": "Driver",
       "Type": "bool"

--- a/tools/cache_creator/cache_creator.cpp
+++ b/tools/cache_creator/cache_creator.cpp
@@ -273,7 +273,8 @@ llvm::Expected<RelocatableCacheCreator> RelocatableCacheCreator::Create(uint32_t
   auto serializer = std::make_unique<vk::PipelineBinaryCacheSerializer>();
   assert(serializer);
 
-  if (serializer->Initialize(privateCacheData.size(), privateCacheData.data()) != Util::Result::Success)
+  if (serializer->Initialize(vk::PipelineCacheBlobFormat::Portable, privateCacheData.size(), privateCacheData.data()) !=
+      Util::Result::Success)
     return llvm::createStringError(std::errc::state_not_recoverable,
                                    "Failed to initialize PipelineBinaryCacheSerializer");
 

--- a/tools/cache_creator/cache_creator_main.cpp
+++ b/tools/cache_creator/cache_creator_main.cpp
@@ -102,11 +102,8 @@ int main(int argc, char **argv) {
     return 4;
   }
 
-  // TODO(kuhar): Initialize the platform key properly by providing the `fingerprint` parameter instead of an empty
-  // array. This is so that the cache can pass validation and be consumed by the ICD. Note that this also requires
-  // ICD-side changes.
   auto cacheCreatorOrErr = cc::RelocatableCacheCreator::Create(
-      DeviceId, uuid, {},
+      DeviceId, uuid, uuid,
       llvm::makeMutableArrayRef((*outFileBufferOrErr)->getBufferStart(), (*outFileBufferOrErr)->getBufferSize()));
   if (auto err = cacheCreatorOrErr.takeError()) {
     llvm::errs() << "Error:\t" << err << "\n";


### PR DESCRIPTION
Introduce a new private pipeline binary cache header field `blobFormat`
with two possible values:
1.  Strict -- uses the existing pipeline cache blob validation. This is
    the default format.
2.  Portable -- creates system-configuration-independent cache blobs that
    can be created offline. This is enabled using a new panel setting
    `EnablePortablePipelineCacheFormat`, so that the ICD only accepts
    the specified

Make the cache-creator tool produce cache blobs in the Portable format.