### PR TITLE
Add cache-creator tool lit tests for basic error handling

### DIFF
--- a/tools/cache_creator/cache_creator.cpp
+++ b/tools/cache_creator/cache_creator.cpp
@@ -219,7 +219,8 @@ llvm::Expected<ElfLlpcCacheInfo> getElfLlpcCacheInfo(llvm::MemoryBufferRef elfBu
     }
   }
 
-  return llvm::createStringError(llvm::object::object_error::invalid_file_type, "Could not find shader/elf elf hash");
+  return llvm::createStringError(llvm::object::object_error::invalid_file_type,
+                                 "Could not find shader/pipeline elf hash");
 }
 
 // =====================================================================================================================

--- a/tools/cache_creator/test/NoElfCacheHash.spvasm
+++ b/tools/cache_creator/test/NoElfCacheHash.spvasm
@@ -1,0 +1,39 @@
+; Check that cache-creator handles ELFs with no cache hash notes and errors out.
+
+; Compile the shader without relocatable compilation enabled.
+; RUN: amdllpc %s %gfxip %spvgen -v -o %t.elf | FileCheck --check-prefix=CHECK-LLPC %s
+; CHECK-LLPC: {{^// LLPC}} SPIRV-to-LLVM translation results
+; CHECK-LLPC: AMDLLPC SUCCESS
+
+; Attempt to create a cache file.
+; RUN: not cache-creator %t.elf --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 -o %t.bin 2>&1 \
+; RUN:   | FileCheck --check-prefix=CHECK-CC %s
+; CHECK-CC: Could not find shader/pipeline elf hash
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 12
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %fragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 460
+               OpName %main "main"
+               OpName %fragColor "fragColor"
+               OpDecorate %fragColor Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %fragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+         %11 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %fragColor %11
+               OpReturn
+               OpFunctionEnd

--- a/tools/cache_creator/test/RequiredCacheCreatorArguments.spvasm
+++ b/tools/cache_creator/test/RequiredCacheCreatorArguments.spvasm
@@ -1,0 +1,28 @@
+; Check that cache-creator requires all the necessary arguments to create a valid cache file.
+; These tests doesn't require SPIR-V input, but we use .spvasm as the file extension so that LIT can pick it up.
+
+; Test 1: Empty input ELF list.
+; RUN: not cache-creator -o %t.bin --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 2>&1 | FileCheck --check-prefix=CHECK-ELFS %s
+; CHECK-ELFS:      Not enough positional command line arguments specified!
+; CHECK-ELFS-NEXT: Must specify at least 1 positional argument
+
+; Test 2: No UUID provided.
+; RUN: not cache-creator -o %t.bin --device-id=0x6080 %s 2>&1 | FileCheck --check-prefix=CHECK-NO-UUID %s
+; CHECK-NO-UUID: for the --uuid option: must be specified at least once!
+
+; Test 3: Invalid UUID provided.
+; RUN: not cache-creator -o %t.bin --uuid=42 --device-id=0x6080 %s 2>&1 | FileCheck --check-prefix=CHECK-INVALID-UUID %s
+; CHECK-INVALID-UUID: Failed to parse pipeline cache UUID
+
+; Test 4: No device ID provided.
+; RUN: not cache-creator -o %t.bin --uuid=00000000-0000-0000-0000-000000000000 2>&1 | FileCheck --check-prefix=CHECK-NO-DID %s
+; CHECK-NO-DID: for the --device-id option: must be specified at least once!
+
+; Test 5: No output file specified.
+; RUN: not cache-creator --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 %s 2>&1 | FileCheck --check-prefix=CHECK-NO-OUT %s
+; CHECK-NO-OUT: for the -o option: must be specified at least once!
+
+; Test 6: Specified input file does not exist.
+; RUN: not cache-creator -o %t.bin --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 %t.does.not.exist.elf 2>&1 \
+; RUN:   | FileCheck --check-prefix=CHECK-BAD-IN %s
+; CHECK-BAD-IN: Failed to read file size


### PR DESCRIPTION
We cannot test successful cache creations until LLPC starts embedding
cache hash notes to produced relocatable ELFs (https://github.com/GPUOpen-Drivers/llpc/pull/1121).