### PR TITLE
Add cache-info tool for analyzing pipeline cache blobs

### DIFF
--- a/tools/cache_creator/CMakeLists.txt
+++ b/tools/cache_creator/CMakeLists.txt
@@ -27,7 +27,7 @@
 # These input elf files can be compiled offline and packaged as cache file on a host machine without a GPU.
 # The "XGL_BUILD_CACHE_CREATOR" CMake option enables the cache creator targets.
 
-# This interface library is intended be used by the cache creator tool and by the related unit tests.
+# This interface library is intended be used by cache-creator, cache-info, and by the related unit tests.
 add_library(cache_creator_lib INTERFACE)
 
 list(APPEND CMAKE_MODULE_PATH "${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm")
@@ -54,18 +54,26 @@ target_compile_definitions(cache_creator_lib INTERFACE
 )
 target_compile_options(cache_creator_lib INTERFACE ${XGL_COMPILE_OPTIONS})
 
-target_sources(cache_creator_lib INTERFACE cache_creator.cpp)
+target_sources(cache_creator_lib INTERFACE cache_creator.cpp cache_info.cpp)
 
 # This executable takes AMDGPU elf files as input and outputs a Vulkan cache file blob
 # that can be later loaded by the ICD.
 # The `cache-creator` binary follows the standard llvm-based tool naming convention.
-# Note that running the cache creator tool doesn't require a Vulkan device to be installed.
+# Note that running the cache-creator tool doesn't require a Vulkan device to be installed.
 add_executable(cache-creator)
 target_sources(cache-creator PRIVATE cache_creator_main.cpp)
 target_link_libraries(cache-creator PRIVATE cache_creator_lib)
 
-# Build cache-creator whenever we build XGL.
-add_dependencies(xgl cache-creator)
+# This executable analyzes pipeline binary cache files produced either by the ICD or by the cache-creator tool.
+# We use the output in automated regression tests but it may also be useful in manual analysis/debugging.
+# The `cache-info` binary follows the standard llvm-based tool naming convention.
+# Note that running the cache-info tool doesn't require a Vulkan device to be installed.
+add_executable(cache-info)
+target_sources(cache-info PRIVATE cache_info_main.cpp)
+target_link_libraries(cache-info PRIVATE cache_creator_lib)
+
+# Build cache creator tools whenever we build XGL.
+add_dependencies(xgl cache-creator cache-info)
 
 if(XGL_BUILD_LIT)
     message(STATUS "Building cache creator LIT tests")
@@ -78,6 +86,7 @@ add_executable(cache-creator-unit-tests)
 target_sources(cache-creator-unit-tests PRIVATE
     units/cache_creator_units_main.cpp
     units/cache_creator_tests.cpp
+    units/cache_info_tests.cpp
 )
 target_include_directories(cache-creator-unit-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(cache-creator-unit-tests PRIVATE cache_creator_lib)

--- a/tools/cache_creator/cache_info.cpp
+++ b/tools/cache_creator/cache_info.cpp
@@ -1,0 +1,263 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+#include "cache_info.h"
+#include "cache_creator.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/MD5.h"
+#include <cassert>
+#include <cinttypes>
+
+namespace {
+
+// =====================================================================================================================
+// Annotates the base error with the blob identifier.
+//
+// @param blob : Cache blob
+// @param err : Base error
+// @returns : Error annotated with the blob identifier
+llvm::Error createBlobError(llvm::MemoryBufferRef blob, llvm::Error err) {
+  return llvm::createFileError(blob.getBufferIdentifier(), std::move(err));
+}
+
+// =====================================================================================================================
+// Creates a string error referencing the blob identifier.
+//
+// @param blob : Cache blob.
+// @param format : Format specifier (printf-style)
+// @param vals : Values for the format specifier
+// @returns : Error annotated with the blob identifier
+template <typename... Ts>
+llvm::Error createBlobError(llvm::MemoryBufferRef blob, const char *format, const Ts &... vals) {
+  return createBlobError(blob, llvm::createStringError(std::errc::state_not_recoverable, format, vals...));
+}
+
+} // namespace
+
+namespace cc {
+
+// =====================================================================================================================
+// Creates a CacheBlobInfo object.
+//
+// @param cacheBlob : Pipeline Cache blob
+// @returns : CacheBlobInfo object on success, error if the cacheBlob cannot be a valid PipelineBinaryCache blob
+llvm::Expected<CacheBlobInfo> CacheBlobInfo::create(llvm::MemoryBufferRef cacheBlob) {
+  constexpr size_t minCacheBlobSize = vk::VkPipelineCacheHeaderDataSize + sizeof(vk::PipelineBinaryCachePrivateHeader);
+  const size_t bufferSize = cacheBlob.getBufferSize();
+
+  if (bufferSize < minCacheBlobSize) {
+    return createBlobError(cacheBlob, "Input buffer too small to be a valid Pipeline Binary Cache blob: %zu B < %zu B",
+                           bufferSize, minCacheBlobSize);
+  }
+
+  assert(cacheBlob.getBufferStart());
+  return CacheBlobInfo{cacheBlob};
+}
+
+// =====================================================================================================================
+// Reads the public Vulkan Pipeline Cache header.
+//
+// @returns : PublicVkHeaderInfo object on success, error if the cache blob does not have a valid public header
+llvm::Expected<PublicVkHeaderInfo> CacheBlobInfo::readPublicVkHeaderInfo() const {
+  PublicVkHeaderInfo res = {};
+  res.publicHeader = reinterpret_cast<const vk::PipelineCacheHeaderData *>(m_cacheBlob.getBufferStart());
+
+  const uint32_t headerLength = res.publicHeader->headerLength;
+  if (headerLength < vk::VkPipelineCacheHeaderDataSize) {
+    return createBlobError(m_cacheBlob,
+                           "Vulkan Pipeline Cache header length too small to be a valid header: %zu B < %zu B",
+                           size_t(headerLength), vk::VkPipelineCacheHeaderDataSize);
+  }
+  if (headerLength >= m_cacheBlob.getBufferSize()) {
+    return createBlobError(m_cacheBlob, "Vulkan Pipeline Cache header length greater than blob size: %zu B >= %zu B",
+                           size_t(headerLength), m_cacheBlob.getBufferSize());
+  }
+
+  res.trailingSpaceBeforePrivateBlob = headerLength - vk::VkPipelineCacheHeaderDataSize;
+  return res;
+}
+
+// =====================================================================================================================
+// Finds the start offset of the private PipelineBinaryCache header.
+//
+// @returns : Private header offset on success, error if the cache blob does not have a valid private header
+llvm::Expected<size_t> CacheBlobInfo::getPrivateHeaderOffset() const {
+  auto *publicHeader = reinterpret_cast<const vk::PipelineCacheHeaderData *>(m_cacheBlob.getBufferStart());
+  size_t privateHeaderOffset = publicHeader->headerLength;
+
+  if (privateHeaderOffset < vk::VkPipelineCacheHeaderDataSize)
+    return createBlobError(m_cacheBlob, "Vulkan Pipeline Cache header length less than expected");
+
+  if (privateHeaderOffset + sizeof(vk::PipelineBinaryCachePrivateHeader) > m_cacheBlob.getBufferSize())
+    return createBlobError(m_cacheBlob, "Insufficient buffer size for the Pipeline Binary Cache private header");
+
+  return privateHeaderOffset;
+}
+
+// =====================================================================================================================
+// Reads the private PipelineBinaryCache header.
+//
+// @returns : BinaryCachePrivateHeader info on success, error if the cache blob does not have a valid private header
+llvm::Expected<BinaryCachePrivateHeaderInfo> CacheBlobInfo::readBinaryCachePrivateHeaderInfo() const {
+  auto privateHeaderOffsetOrErr = getPrivateHeaderOffset();
+  if (auto err = privateHeaderOffsetOrErr.takeError())
+    return std::move(err);
+
+  BinaryCachePrivateHeaderInfo res = {};
+  res.privateHeader = reinterpret_cast<const vk::PipelineBinaryCachePrivateHeader *>(m_cacheBlob.getBufferStart() +
+                                                                                     *privateHeaderOffsetOrErr);
+  res.contentBlobSize =
+      m_cacheBlob.getBufferSize() - (*privateHeaderOffsetOrErr + sizeof(vk::PipelineBinaryCachePrivateHeader));
+  return res;
+}
+
+// =====================================================================================================================
+// Finds the start offset of the cache content.
+//
+// @returns : Cache content offset on success, error if the cache blob does not have any valid content (not even empty)
+llvm::Expected<size_t> CacheBlobInfo::getCacheContentOffset() const {
+  auto privateHeaderOffsetOrErr = getPrivateHeaderOffset();
+  if (auto err = privateHeaderOffsetOrErr.takeError())
+    return std::move(err);
+
+  return *privateHeaderOffsetOrErr + sizeof(vk::PipelineBinaryCachePrivateHeader);
+}
+
+// =====================================================================================================================
+// Reads all PipelineBinaryCache entries. For each entry, calculates information about its location within the cache
+// blob, and computes the MD5 sum of the entry's content.
+//
+// @param [out] entriesInfoOut : The cache entries found
+// @returns : Error if the cache blob does not have a valid content section, success otherwise
+llvm::Error
+CacheBlobInfo::readBinaryCacheEntriesInfo(llvm::SmallVectorImpl<BinaryCacheEntryInfo> &entriesInfoOut) const {
+  auto contentOffsetOrErr = getCacheContentOffset();
+  if (auto err = contentOffsetOrErr.takeError())
+    return std::move(err);
+
+  constexpr size_t EntrySize = sizeof(vk::BinaryCacheEntry);
+  const uint8_t *const blobStart = reinterpret_cast<const uint8_t *>(m_cacheBlob.getBufferStart());
+  const uint8_t *const blobEnd = reinterpret_cast<const uint8_t *>(m_cacheBlob.getBufferEnd());
+  const uint8_t *currData = blobStart + *contentOffsetOrErr;
+
+  for (size_t entryIdx = 0; currData < blobEnd; ++entryIdx) {
+    const size_t currEntryOffset = currData - blobStart;
+    if (currData + EntrySize > blobEnd) {
+      return createBlobError(m_cacheBlob, "Insufficient buffer size for cache entry header #%zu at offset %zu",
+                             entryIdx, currEntryOffset);
+    }
+
+    BinaryCacheEntryInfo currEntryInfo = {};
+    currEntryInfo.entryHeader = reinterpret_cast<const vk::BinaryCacheEntry *>(currData);
+    currEntryInfo.idx = entryIdx;
+
+    const size_t currEntryBlobSize = currEntryInfo.entryHeader->dataSize;
+    if (currData + EntrySize + currEntryBlobSize > blobEnd) {
+      return createBlobError(m_cacheBlob, "Insufficient buffer size for cache entry content #%zu at offset %zu",
+                             entryIdx, currEntryOffset);
+    }
+
+    currData += EntrySize;
+    currEntryInfo.entryBlob = {currData, currEntryBlobSize};
+    currData += currEntryBlobSize;
+
+    llvm::MD5 md5;
+    md5.update(currEntryInfo.entryBlob);
+    llvm::MD5::MD5Result result = {};
+    md5.final(result);
+    currEntryInfo.entryMD5Sum = result.digest();
+
+    entriesInfoOut.push_back(std::move(currEntryInfo));
+  }
+
+  return llvm::Error::success();
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const PublicVkHeaderInfo &info) {
+  assert(info.publicHeader);
+  const vk::PipelineCacheHeaderData &header = *info.publicHeader;
+
+  os << "=== Vulkan Pipeline Cache Header ===\n"
+     << "header length:\t\t" << header.headerLength << "\n"
+     << "header version:\t\t" << header.headerVersion << "\n"
+     << "vendor ID:\t\t" << llvm::format("0x%" PRIx32, header.vendorID) << "\n"
+     << "device ID:\t\t" << llvm::format("0x%" PRIx32, header.deviceID) << "\n"
+     << "pipeline cache UUID:\t" << cc::uuidToHexString(header.UUID) << "\n";
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const BinaryCachePrivateHeaderInfo &info) {
+  assert(info.privateHeader);
+  const vk::PipelineBinaryCachePrivateHeader &header = *info.privateHeader;
+
+  os << "=== Pipeline Binary Cache Private Header ===\n"
+     << "header length:\t" << sizeof(header) << "\n"
+     << "hash ID:\t" << llvm::format_bytes(header.hashId, llvm::None, sizeof(header.hashId)) << "\n"
+     << "content size:\t" << info.contentBlobSize << "\n";
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const BinaryCacheEntryInfo &info) {
+  assert(info.entryHeader);
+  const vk::BinaryCacheEntry &header = *info.entryHeader;
+
+  os << "\t*** Entry " << info.idx << " ***\n"
+     << "\thash ID:\t\t" << llvm::format_bytes(header.hashId.bytes, llvm::None, 16, 1) << "\n"
+     << "\tdata size:\t\t" << header.dataSize << "\n"
+     << "\tcalculated MD5 sum:\t" << info.entryMD5Sum << "\n";
+  return os;
+}
+
+// =====================================================================================================================
+// Returns a map from the MD5 sum of a files contents to the file's path for every '.elf' file in `dir` or any of its
+// subdirectories.
+// If there are multiple '.elf' files sharing the same MD5, a single (arbitrary) file path is kept as the value of that
+// map entry.
+//
+// @param dir : The directory to search
+// @returns : Map from ELF MD5 sums to their paths on disk
+llvm::StringMap<std::string> mapMD5SumsToElfFilePath(llvm::Twine dir) {
+  namespace fs = llvm::sys::fs;
+  llvm::StringMap<std::string> md5ToElfPath;
+
+  std::error_code ec{};
+  for (fs::recursive_directory_iterator it{dir, ec}, e{}; it != e && !ec; it.increment(ec)) {
+    const std::string &path(it->path());
+    if (!llvm::StringRef(path).endswith(".elf") || fs::is_directory(path))
+      continue;
+
+    llvm::ErrorOr<llvm::MD5::MD5Result> elfMD5OrErr = fs::md5_contents(path);
+    if (std::error_code err = elfMD5OrErr.getError()) {
+      llvm::errs() << "[WARN]: Can not read source ELF file " << path << ": " << err.message() << "\n";
+      continue;
+    }
+
+    md5ToElfPath.insert({elfMD5OrErr->digest(), path});
+  }
+
+  return md5ToElfPath;
+}
+
+} // namespace cc

--- a/tools/cache_creator/cache_info.h
+++ b/tools/cache_creator/cache_info.h
@@ -1,0 +1,114 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+#pragma once
+
+#include "include/binary_cache_serialization.h"
+
+// These Xlib defines conflict with LLVM.
+#undef Bool
+#undef Status
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include <string>
+
+namespace cc {
+
+// =====================================================================================================================
+//
+// This API allows to analyze and print XGL's PipelineBinaryCache blobs. It is not meant to work with other
+// Vulkan Pipeline Cache blob formats.
+//
+// PipelineBinaryCache consist of 3 parts:
+// -  Public Vulkan Pipeline Cache header
+// -  Private PipelineBinaryCache header
+// -  Sequence of PipelineBinaryCache entries
+//
+// For detailed information about PipelineBinaryCache structure, see
+// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineCacheData.html and
+// `xgl/icd/api/include/binary_cache_serialization.h`.
+//
+// =====================================================================================================================
+
+// Represents printable information about the public Vulkan Pipeline Cache header.
+struct PublicVkHeaderInfo {
+  const vk::PipelineCacheHeaderData *publicHeader;
+  size_t trailingSpaceBeforePrivateBlob;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const PublicVkHeaderInfo &info);
+
+// Represents printable information about the private Pipeline Binary Cache header.
+struct BinaryCachePrivateHeaderInfo {
+  const vk::PipelineBinaryCachePrivateHeader *privateHeader;
+  size_t contentBlobSize;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const BinaryCachePrivateHeaderInfo &info);
+
+using MD5DigestStr = llvm::SmallString<32>;
+
+// Represents printable information about a Pipeline Binary Cache entry, its location within the cache blob, and
+// calculated MD5 sum of the entry content.
+struct BinaryCacheEntryInfo {
+  const vk::BinaryCacheEntry *entryHeader;
+  size_t idx;
+  llvm::ArrayRef<uint8_t> entryBlob;
+  MD5DigestStr entryMD5Sum;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const BinaryCacheEntryInfo &info);
+
+// Given a directory, returns a map from ELF MD5 sums their paths. Files without the '.elf' extension ignored.
+llvm::StringMap<std::string> mapMD5SumsToElfFilePath(llvm::Twine dir);
+
+// Analyzes given PipelineBinaryCache file. It it valid to use it with invalid or partially-valid cache blobs.
+// Note: Member functions do not have to be called in any particular order.
+class CacheBlobInfo {
+public:
+  static llvm::Expected<CacheBlobInfo> create(llvm::MemoryBufferRef cacheBlob);
+
+  llvm::Expected<PublicVkHeaderInfo> readPublicVkHeaderInfo() const;
+
+  llvm::Expected<BinaryCachePrivateHeaderInfo> readBinaryCachePrivateHeaderInfo() const;
+
+  llvm::Error readBinaryCacheEntriesInfo(llvm::SmallVectorImpl<BinaryCacheEntryInfo> &entriesInfoOut) const;
+
+  llvm::Expected<size_t> getPrivateHeaderOffset() const;
+  llvm::Expected<size_t> getCacheContentOffset() const;
+
+private:
+  CacheBlobInfo(llvm::MemoryBufferRef cacheBlob) : m_cacheBlob(cacheBlob) {}
+
+  llvm::MemoryBufferRef m_cacheBlob;
+};
+
+} // namespace cc

--- a/tools/cache_creator/cache_info_main.cpp
+++ b/tools/cache_creator/cache_info_main.cpp
@@ -1,0 +1,107 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+#include "cache_info.h"
+#include "llvm/Support/CommandLine.h"
+#include <cassert>
+
+namespace {
+llvm::cl::OptionCategory CacheInfoCat("Cache Info Options");
+
+llvm::cl::opt<std::string> InFile(llvm::cl::Positional, llvm::cl::ValueRequired, llvm::cl::cat(CacheInfoCat),
+                                  llvm::cl::desc("<Input cache_file.bin>"));
+llvm::cl::opt<std::string> ElfSourceDir("elf-source-dir", llvm::cl::desc("(Optional) Directory with source ELF files"),
+                                        llvm::cl::cat(CacheInfoCat), llvm::cl::value_desc("directory"));
+
+int reportAndConsumeError(llvm::Error err, int exitCode) {
+  llvm::errs() << "[ERROR]: " << err << "\n";
+  llvm::consumeError(std::move(err));
+  return exitCode;
+}
+} // namespace
+
+namespace fs = llvm::sys::fs;
+
+int main(int argc, char **argv) {
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> inputBufferOrErr = llvm::MemoryBuffer::getFile(InFile);
+  if (auto err = inputBufferOrErr.getError()) {
+    llvm::errs() << "Failed to read input file " << InFile << ": " << err.message() << "\n";
+    return 3;
+  }
+  llvm::outs() << "Read: " << InFile << ", " << (*inputBufferOrErr)->getBufferSize() << " B\n\n";
+
+  auto blobInfoOrErr = cc::CacheBlobInfo::create(**inputBufferOrErr);
+  if (auto err = blobInfoOrErr.takeError())
+    return reportAndConsumeError(std::move(err), 4);
+  const cc::CacheBlobInfo &blobInfo = *blobInfoOrErr;
+
+  auto publicHeaderInfoOrErr = blobInfo.readPublicVkHeaderInfo();
+  if (auto err = publicHeaderInfoOrErr.takeError())
+    return reportAndConsumeError(std::move(err), 4);
+  llvm::outs() << *publicHeaderInfoOrErr << "\n";
+
+  auto privateHeaderInfoOrErr = blobInfo.readBinaryCachePrivateHeaderInfo();
+  if (auto err = privateHeaderInfoOrErr.takeError())
+    return reportAndConsumeError(std::move(err), 4);
+  llvm::outs() << *privateHeaderInfoOrErr << "\n";
+
+  llvm::StringMap<std::string> elfMD5ToFilePath;
+  if (!ElfSourceDir.empty()) {
+    llvm::SmallVector<char> rawElfSourceDir;
+    if (std::error_code err = fs::real_path(ElfSourceDir, rawElfSourceDir, /* expand_tilde = */ true)) {
+      llvm::errs() << "[ERROR]: --elf-source-dir: " << ElfSourceDir << "could not be expanded: " << err.message()
+                   << "\n";
+      return 3;
+    }
+    llvm::StringRef elfSourceDirReal(rawElfSourceDir.begin(), rawElfSourceDir.size());
+
+    if (!fs::is_directory(elfSourceDirReal)) {
+      llvm::errs() << "[ERROR]: --elf-source-dir: " << elfSourceDirReal << " is not a directory!\n";
+      return 3;
+    }
+    elfMD5ToFilePath = cc::mapMD5SumsToElfFilePath(elfSourceDirReal);
+  }
+
+  llvm::SmallVector<cc::BinaryCacheEntryInfo> entries;
+  if (auto cacheEntriesReadErr = blobInfo.readBinaryCacheEntriesInfo(entries))
+    return reportAndConsumeError(std::move(cacheEntriesReadErr), 4);
+
+  llvm::outs() << "=== Cache Content Info ===\n"
+               << "total num entries: " << entries.size() << "\n\n";
+
+  for (const cc::BinaryCacheEntryInfo &entryInfo : entries) {
+    llvm::StringRef sourceFilePath = "<none>";
+    auto sourceElfIt = elfMD5ToFilePath.find(entryInfo.entryMD5Sum);
+    if (sourceElfIt != elfMD5ToFilePath.end())
+      sourceFilePath = sourceElfIt->second;
+
+    llvm::outs() << entryInfo << "\tmatched source file:\t" << sourceFilePath << "\n\n";
+  }
+
+  llvm::outs() << "\n=== Cache Info analysis finished ===\n";
+  return 0;
+}

--- a/tools/cache_creator/test/CMakeLists.txt
+++ b/tools/cache_creator/test/CMakeLists.txt
@@ -49,5 +49,5 @@ configure_lit_site_cfg(
 # You can execute test by building the `check-cache-creator` target, e.g., `ninja check-cache-creator`.
 add_lit_testsuite(check-cache-creator "Running the XGL cache creator regression tests"
     ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS cache-creator amdllpc spvgen FileCheck count not split-file
+    DEPENDS cache-creator cache-info amdllpc spvgen FileCheck count not split-file
 )

--- a/tools/cache_creator/test/RunLitCommands.spvasm
+++ b/tools/cache_creator/test/RunLitCommands.spvasm
@@ -6,6 +6,9 @@
 ; RUN: cache-creator --help | FileCheck -check-prefix=CHECK-CC %s
 ; CHECK-CC: Cache Creator Options
 
+; RUN: cache-info --help | FileCheck -check-prefix=CHECK-CI %s
+; CHECK-CI: Cache Info Options
+
 ; RUN: llvm-objdump --version | FileCheck -check-prefix=CHECK-OBJDUMP %s
 ; CHECK-OBJDUMP: Registered Targets
 

--- a/tools/cache_creator/test/lit.cfg.py
+++ b/tools/cache_creator/test/lit.cfg.py
@@ -57,5 +57,5 @@ config.substitutions.append(('%spvgen', '-spvgen-dir=' + config.spvgen_dir))
 config.substitutions.append(('%reloc', '-unlinked -enable-relocatable-shader-elf'))
 
 tool_dirs = [config.cache_creator_tools_dir, config.amdllpc_dir, config.llvm_tools_dir]
-tools = ['amdllpc', 'cache-creator', 'llvm-objdump', 'llvm-readelf', 'count', 'not', 'split-file']
+tools = ['amdllpc', 'cache-creator', 'cache-info', 'llvm-objdump', 'llvm-readelf', 'count', 'not', 'split-file']
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/tools/cache_creator/units/cache_info_tests.cpp
+++ b/tools/cache_creator/units/cache_info_tests.cpp
@@ -1,0 +1,203 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+#include "cache_info.h"
+#include "units/doctest.h"
+#include "llvm/Support/MD5.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include <cassert>
+
+static bool consumeErrorToBool(llvm::Error err) {
+  const bool isError = bool(err);
+  if (isError) {
+    llvm::errs() << err << "\n";
+    llvm::errs().flush();
+  }
+  llvm::consumeError(std::move(err));
+  return isError;
+}
+
+template <typename T> static bool consumeErrorToBool(llvm::Expected<T> &valueOrErr) {
+  return consumeErrorToBool(valueOrErr.takeError());
+}
+
+TEST_CASE("Empty cache blob") {
+  auto blobPtr = llvm::MemoryBuffer::getMemBuffer(llvm::StringRef{}, "empty", false);
+  assert(blobPtr);
+  auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
+  CHECK(consumeErrorToBool(blobInfoOrErr));
+}
+
+TEST_CASE("Large zero blob") {
+  llvm::SmallVector<uint8_t> zeros(512u);
+  auto blobPtr = llvm::MemoryBuffer::getMemBuffer(llvm::toStringRef(zeros), "zeros", false);
+  assert(blobPtr);
+  auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
+  CHECK(!consumeErrorToBool(blobInfoOrErr));
+
+  // This should fail as the self-declared header length is 0.
+  auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
+  CHECK(consumeErrorToBool(publicHeaderInfoOrErr));
+
+  // This should fail as the self-declared header length is 0.
+  auto privateHeaderOffsetOrErr = blobInfoOrErr->getPrivateHeaderOffset();
+  CHECK(consumeErrorToBool(privateHeaderOffsetOrErr));
+}
+
+TEST_CASE("Public header only") {
+  vk::PipelineCacheHeaderData publicHeader = {};
+  publicHeader.headerLength = sizeof(publicHeader);
+  auto blobPtr = llvm::MemoryBuffer::getMemBuffer(
+      llvm::StringRef(reinterpret_cast<const char *>(&publicHeader), sizeof(publicHeader)), "public_header", false);
+  assert(blobPtr);
+
+  // These should fail as the blob is not big enough to contain both a public and a private header.
+  auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
+  CHECK(consumeErrorToBool(blobInfoOrErr));
+}
+
+TEST_CASE("Public header length too long") {
+  llvm::SmallVector<uint8_t> buffer(vk::VkPipelineCacheHeaderDataSize + sizeof(vk::PipelineBinaryCachePrivateHeader));
+  auto *publicHeader = new (buffer.data()) vk::PipelineCacheHeaderData();
+  publicHeader->headerLength = vk::VkPipelineCacheHeaderDataSize + 1;
+
+  auto blobPtr = llvm::MemoryBuffer::getMemBuffer(llvm::toStringRef(buffer), "public_header_len", false);
+  assert(blobPtr);
+
+  // This should succeed because we don't parse the public header at this point and don't know the public header length.
+  auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
+  CHECK(!consumeErrorToBool(blobInfoOrErr));
+
+  // This should succeed as the public header can be fully parsed.
+  auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
+  CHECK(!consumeErrorToBool(publicHeaderInfoOrErr));
+  CHECK(publicHeaderInfoOrErr->publicHeader == publicHeader);
+  CHECK(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob == 1);
+
+  // This should fail as the self-declared header length is too long to fit the private header.
+  auto privateHeaderOffsetOrErr = blobInfoOrErr->getPrivateHeaderOffset();
+  CHECK(consumeErrorToBool(privateHeaderOffsetOrErr));
+
+  // This should fail as the self-declared header length is too long to fit the private header.
+  auto privateHeaderInfoOrErr = blobInfoOrErr->readBinaryCachePrivateHeaderInfo();
+  CHECK(consumeErrorToBool(privateHeaderInfoOrErr));
+}
+
+TEST_CASE("Valid blob w/o entries") {
+  llvm::SmallVector<uint8_t> buffer(vk::VkPipelineCacheHeaderDataSize + sizeof(vk::PipelineBinaryCachePrivateHeader));
+  auto *publicHeader = new (buffer.data()) vk::PipelineCacheHeaderData();
+  auto *privateHeader = new (buffer.data() + vk::VkPipelineCacheHeaderDataSize) vk::PipelineBinaryCachePrivateHeader();
+  publicHeader->headerLength = vk::VkPipelineCacheHeaderDataSize;
+
+  auto blobPtr = llvm::MemoryBuffer::getMemBuffer(llvm::toStringRef(buffer), "valid_no_entries", false);
+  assert(blobPtr);
+
+  auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
+  CHECK(!consumeErrorToBool(blobInfoOrErr));
+
+  // These should succeed as both headers can be fully parsed.
+  auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
+  CHECK(!consumeErrorToBool(publicHeaderInfoOrErr));
+  CHECK(publicHeaderInfoOrErr->publicHeader == publicHeader);
+  CHECK(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob == 0);
+
+  auto privateHeaderOffsetOrErr = blobInfoOrErr->getPrivateHeaderOffset();
+  CHECK(!consumeErrorToBool(privateHeaderOffsetOrErr));
+  CHECK(*privateHeaderOffsetOrErr == vk::VkPipelineCacheHeaderDataSize);
+
+  auto privateHeaderInfoOrErr = blobInfoOrErr->readBinaryCachePrivateHeaderInfo();
+  CHECK(!consumeErrorToBool(privateHeaderInfoOrErr));
+  CHECK(privateHeaderInfoOrErr->privateHeader == privateHeader);
+  CHECK(privateHeaderInfoOrErr->contentBlobSize == 0);
+
+  auto contentOffsetOrErr = blobInfoOrErr->getCacheContentOffset();
+  CHECK(!consumeErrorToBool(contentOffsetOrErr));
+  CHECK(*contentOffsetOrErr == buffer.size());
+
+  // This should succeed as it is valid to have an empty cache content, i.e., zero entries.
+  llvm::SmallVector<cc::BinaryCacheEntryInfo, 0> entries;
+  auto err = blobInfoOrErr->readBinaryCacheEntriesInfo(entries);
+  CHECK(!consumeErrorToBool(std::move(err)));
+  CHECK(entries.empty());
+}
+
+static cc::MD5DigestStr calculateMD5Sum(llvm::ArrayRef<uint8_t> data) {
+  llvm::MD5 md5;
+  md5.update(data);
+  llvm::MD5::MD5Result result = {};
+  md5.final(result);
+  return result.digest();
+}
+
+TEST_CASE("Valid blob w/ one entry") {
+  const size_t trailingSpace = 16;
+  const size_t entrySize = sizeof(uint32_t);
+  const size_t bufferSize = vk::VkPipelineCacheHeaderDataSize + trailingSpace +
+                            sizeof(vk::PipelineBinaryCachePrivateHeader) + sizeof(vk::BinaryCacheEntry) + entrySize;
+  llvm::SmallVector<uint8_t> buffer(bufferSize);
+  uint8_t *currData = buffer.data();
+
+  auto *publicHeader = new (currData) vk::PipelineCacheHeaderData();
+  publicHeader->headerLength = vk::VkPipelineCacheHeaderDataSize + trailingSpace;
+  currData += publicHeader->headerLength;
+
+  auto *privateHeader = new (currData) vk::PipelineBinaryCachePrivateHeader();
+  currData += sizeof(vk::PipelineBinaryCachePrivateHeader);
+
+  auto *entryHeader = new (currData) vk::BinaryCacheEntry();
+  entryHeader->dataSize = entrySize;
+  currData += sizeof(vk::BinaryCacheEntry);
+
+  auto *entryContent = new (currData) uint32_t(42);
+  llvm::ArrayRef<uint8_t> entryBlob(currData, entrySize);
+
+  auto blobPtr = llvm::MemoryBuffer::getMemBuffer(llvm::toStringRef(buffer), "valid_one_entry", false);
+  assert(blobPtr);
+
+  auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
+  CHECK(!consumeErrorToBool(blobInfoOrErr));
+
+  // These should all succeed as both headers can be fully parsed and there's one valid entry.
+  auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
+  CHECK(!consumeErrorToBool(publicHeaderInfoOrErr));
+  CHECK(publicHeaderInfoOrErr->publicHeader == publicHeader);
+  CHECK(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob == trailingSpace);
+
+  auto privateHeaderInfoOrErr = blobInfoOrErr->readBinaryCachePrivateHeaderInfo();
+  CHECK(!consumeErrorToBool(privateHeaderInfoOrErr));
+  CHECK(privateHeaderInfoOrErr->privateHeader == privateHeader);
+  CHECK(privateHeaderInfoOrErr->contentBlobSize == (sizeof(vk::BinaryCacheEntry) + entrySize));
+
+  llvm::SmallVector<cc::BinaryCacheEntryInfo, 1> entries;
+  auto err = blobInfoOrErr->readBinaryCacheEntriesInfo(entries);
+  CHECK(!consumeErrorToBool(std::move(err)));
+  CHECK(entries.size() == 1);
+
+  cc::BinaryCacheEntryInfo &entry = entries.front();
+  CHECK(entry.entryHeader == entryHeader);
+  CHECK(entry.idx == 0);
+  CHECK(entry.entryBlob.data() == entryBlob.data());
+  CHECK(entry.entryBlob.size() == entryBlob.size());
+  CHECK(entry.entryMD5Sum == calculateMD5Sum(entryBlob));
+}


### PR DESCRIPTION
The primary use for cache-info is analyzing cache blobs created
by either the ICD or cache-creator. This can be useful in both
manual workflows and in future LIT regression tests.

For more context, see https://github.com/GPUOpen-Drivers/xgl/issues/75.

This adds the initial cache-info tool and unit tests that excercise the
error handling logic. More LIT tests will be added after
https://github.com/GPUOpen-Drivers/xgl/pull/94 gets merged.