### PR TITLE
Check ELF LLPC version against interface version from vkgcDefs

### DIFF
--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -502,6 +502,7 @@ target_sources(xgl_cache_support INTERFACE
 )
 target_include_directories(xgl_cache_support INTERFACE
     api
+    api/include/khronos
 )
 target_link_libraries(xgl_cache_support INTERFACE pal)
 

--- a/tools/cache_creator/CMakeLists.txt
+++ b/tools/cache_creator/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(cache_creator_lib INTERFACE pal xgl_cache_support ${llvm_l
 target_include_directories(cache_creator_lib INTERFACE
     ${XGL_LLVM_SRC_PATH}/include
     ${LLVM_INCLUDE_DIRS}  # This is necessary to discover the auto-generated llvm-config.h header.
+    ${XGL_VKGC_PATH}/include
 )
 
 get_target_property(XGL_COMPILE_OPTIONS xgl COMPILE_OPTIONS)
@@ -50,7 +51,6 @@ get_target_property(XGL_COMPILE_DEFINITIONS xgl COMPILE_DEFINITIONS)
 target_compile_definitions(cache_creator_lib INTERFACE
     ${LLVM_DEFINITIONS}
     ${XGL_COMPILE_DEFINITIONS}
-    CC_LLPC_MAJOR_VERSION=${LLPC_MAJOR_VERSION}
 )
 target_compile_options(cache_creator_lib INTERFACE ${XGL_COMPILE_OPTIONS})
 

--- a/tools/cache_creator/cache_creator.h
+++ b/tools/cache_creator/cache_creator.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "util/palMetroHash.h"
+#include "vkgcDefs.h"
 #include "include/binary_cache_serialization.h"
 
 // These Xlib defines conflict with LLVM.
@@ -42,7 +43,8 @@ namespace cc {
 constexpr uint32_t AMDVendorId = 0x1002; // See https://pci-ids.ucw.cz/read/PC/1002.
 
 // The LLPC version number in the current source tree.
-constexpr uint32_t BuildLlpcMajorVersion = CC_LLPC_MAJOR_VERSION;
+constexpr uint32_t BuildLlpcMajorVersion = LLPC_INTERFACE_MAJOR_VERSION;
+constexpr uint32_t BuildLlpcMinorVersion = LLPC_INTERFACE_MINOR_VERSION;
 
 VkAllocationCallbacks &getDefaultAllocCallbacks();
 


### PR DESCRIPTION
Shader/pipeline cache hashes produced by LLPC are only valid for the
same LLPC-defined version. Use the LLPC version from vkgcDefs so that
we don't we can detect when ELF cache hashes don't match LLPC from
the current source tree.