### PR TITLE
In PipelineCache, return nullptr cache adapter if PBC is nullptr

### DIFF
--- a/icd/api/include/vk_pipeline_cache.h
+++ b/icd/api/include/vk_pipeline_cache.h
@@ -69,7 +69,10 @@ public:
     VkResult Merge(uint32_t srcCacheCount, const PipelineCache** ppSrcCaches);
 
     VK_INLINE PipelineBinaryCache* GetPipelineCache() const { return m_pBinaryCache; }
-    Vkgc::ICache* GetCacheAdapter() const { return m_pBinaryCache->GetCacheAdapter(); }
+    Vkgc::ICache* GetCacheAdapter() const
+    {
+      return (m_pBinaryCache != nullptr ? m_pBinaryCache->GetCacheAdapter() : nullptr);
+    }
 
 protected:
     PipelineCache(const Device*  pDevice,


### PR DESCRIPTION
In the PipelineCache class, the member `m_pBinaryCache` will be null if
the `allowExternalPipelineCacheObject` setting is false. See
PipelineCache::Create.  However, the function `PipelineCache::GetCacheAdapter`
assumes that `m_pBinaryCache` is not nullptr.  This can cause a
segmentation fault.

This is fixed by returning `nullptr` in `PipelineCache::GetCacheAdapter`
if `m_pBinaryCache` is nullptr.