### PR TITLE
Extend lit tests to check for cache file contents

### DIFF
--- a/tools/cache_creator/cache_info.cpp
+++ b/tools/cache_creator/cache_info.cpp
@@ -204,7 +204,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const PublicVkHeaderInfo &i
      << "header version:\t\t" << header.headerVersion << "\n"
      << "vendor ID:\t\t" << llvm::format("0x%" PRIx32, header.vendorID) << "\n"
      << "device ID:\t\t" << llvm::format("0x%" PRIx32, header.deviceID) << "\n"
-     << "pipeline cache UUID:\t" << cc::uuidToHexString(header.UUID) << "\n";
+     << "pipeline cache UUID:\t" << cc::uuidToHexString(header.UUID) << "\n"
+     << "trailing space:\t" << info.trailingSpaceBeforePrivateBlob << "\n";
   return os;
 }
 

--- a/tools/cache_creator/cache_info_main.cpp
+++ b/tools/cache_creator/cache_info_main.cpp
@@ -91,7 +91,8 @@ int main(int argc, char **argv) {
     return reportAndConsumeError(std::move(cacheEntriesReadErr), 4);
 
   llvm::outs() << "=== Cache Content Info ===\n"
-               << "total num entries: " << entries.size() << "\n\n";
+               << "total num entries: " << entries.size() << "\n"
+               << "entry header length: " << sizeof(vk::BinaryCacheEntry) << "\n\n";
 
   for (const cc::BinaryCacheEntryInfo &entryInfo : entries) {
     llvm::StringRef sourceFilePath = "<none>";

--- a/tools/cache_creator/test/BasicCacheCreation.spvasm
+++ b/tools/cache_creator/test/BasicCacheCreation.spvasm
@@ -1,44 +1,153 @@
-; Check that cache-creator can create cache files from one or two elf entries.
+; Check that cache-creator can create cache files from one or two elf entries,
+; and that cache-info can read them.
 
 ; Split the test into two .spvasm temporary inputs.
 ; RUN: split-file %s %t
 
-; Compile the vertex shader into a relocatable ELF.
-; RUN: amdllpc %t/vert.spvasm %gfxip %spvgen %reloc -add-hash-to-elf -v -o %t.vert.elf | FileCheck --check-prefix=LLPC-VERT %s
+; Compile the vertex shader into a relocatable ELF. Save the compilation output to a log so that other test can refer to it.
+; RUN: amdllpc %t/vert.spvasm %gfxip %spvgen %reloc -add-hash-to-elf -v -o %t.vert.elf > %t.vert.amdllpc.log 2>&1 \
+; RUN:   && cat %t.vert.amdllpc.log | FileCheck --check-prefix=LLPC-VERT %s
 ; LLPC-VERT-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; LLPC-VERT-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====
 
-; Compile the fragment shader into a relocatable ELF.
-; RUN: amdllpc %t/frag.spvasm %gfxip %spvgen %reloc -add-hash-to-elf -v -o %t.frag.elf | FileCheck --check-prefix=LLPC-FRAG %s
+; Compile the fragment shader into a relocatable ELF. Save the compilation output to a log so that other test can refer to it.
+; RUN: amdllpc %t/frag.spvasm %gfxip %spvgen %reloc -add-hash-to-elf -v -o %t.frag.elf > %t.frag.amdllpc.log 2>&1 \
+; RUN:   && cat %t.frag.amdllpc.log | FileCheck --check-prefix=LLPC-VERT %s
 ; LLPC-FRAG-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; LLPC-FRAG-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====
 
-; Test 1: Create a cache file with one input.
-; RUN: cache-creator %t.vert.elf --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 -o %t.vert.bin --verbose \
-; RUN:   | FileCheck --check-prefix=CC-VERT %s
-; CC-VERT:       {{^Num}} inputs: 1, anticipated cache size: [[ver_cache_size:[0-9]+]]{{$}}
-; CC-VERT-NEXT:  {{^Read:}} {{.*}}.vert.elf{{$}}
-; CC-VERT:       {{^Num}} entries written: 1, actual cache size: [[ver_cache_size]] B{{$}}
-; CC-VERT-LABEL: {{^Cache}} successfully written to: {{.*}}.vert.bin{{$}}
 
-; Test 2: Create a cache file with two inputs.
-; RUN: cache-creator %t.vert.elf %t.frag.elf --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 -o %t.vert-frag.bin --verbose \
+; Test 1: Create a cache file with one input. Check that the cache contents have the right format
+;         and are read back as expected.
+; RUN: cache-creator %t.vert.elf --uuid=00000001-0020-0300-4000-50000000000f --device-id=0x6080 \
+; RUN:               -o %t.vert.bin --verbose > %t.vert.cc.log 2>&1 \
+; RUN:   && cache-info %t.vert.bin > %t.vert.ci.log 2>&1 \
+; RUN:   && cat %t.vert.cc.log %t.vert.ci.log %t.vert.amdllpc.log | FileCheck --check-prefix=CC-VERT %s
+; Part 1a: Check cache-creator output.
+; CC-VERT:       {{^Num}} inputs: 1, anticipated cache size: [[#vert_cache_size:]]{{$}}
+; CC-VERT-NEXT:  {{^Read:}} {{.*}}.vert.elf{{$}}
+; CC-VERT:       {{^Num}} entries written: 1, actual cache size: [[#vert_cache_size]] B{{$}}
+; CC-VERT:       {{^Cache}} successfully written to: [[cache_file_path:.*\.vert\.bin]]{{$}}
+;
+; Part 1b: Check cache-info output.
+; CC-VERT:       {{^Read:}} [[cache_file_path]], [[#vert_cache_size]] B{{$}}
+;
+; CC-VERT-LABEL: {{^===}} Vulkan Pipeline Cache Header
+; CC-VERT-NEXT:  {{^header length:}} [[#vk_header_len:32]]{{$}}
+; CC-VERT-NEXT:  {{^header version:}} 1{{$}}
+; CC-VERT-NEXT:  {{^vendor ID:}} 0x1002{{$}}
+; CC-VERT-NEXT:  {{^device ID:}} 0x6080{{$}}
+; CC-VERT-NEXT:  {{^pipeline cache UUID:}} 00000001-0020-0300-4000-50000000000f{{$}}
+; CC-VERT-NEXT:  {{^trailing space:}} 0{{$}}
+;
+; CC-VERT-LABEL: {{^===}} Pipeline Binary Cache Private Header
+; CC-VERT-NEXT:  {{^header length:}} [[#pbc_header_len:20]]{{$}}
+; CC-VERT-NEXT:  {{^hash ID:}} {{([0-9a-f]{8} ?){5}$}}
+; CC-VERT-NEXT:  {{^content size:}} [[#vert_cache_size - vk_header_len - pbc_header_len]]{{$}}
+;
+; CC-VERT-LABEL: {{^===}} Cache Content Info
+; CC-VERT-NEXT:  {{^total num entries:}} 1{{$}}
+; CC-VERT-NEXT:  {{^entry header length:}} [[#entry_header_len:24]]{{$}}
+; CC-VERT-LABEL: {{^}} *** Entry 0 ***
+; CC-VERT-NEXT:  {{^}} hash ID: [[vert_cache_hash:([0-9a-f]{2} ?){16}]]{{$}}
+; CC-VERT-NEXT:  {{^}} data size: [[#vert_cache_size - vk_header_len - pbc_header_len - entry_header_len]]{{$}}
+; CC-VERT-NEXT:  {{^}} calculated MD5 sum: {{[0-9a-f]{32}$}}
+; CC-VERT-NEXT:  {{^}} matched source file: <none>{{$}}
+;
+; CC-VERT-LABEL: {{^===}} Cache Info analysis finished
+;
+; Part 1c: Check amdllpc output to see that the entry hash ID from 1b matches the compiler vertex cache hash.
+; CC-VERT:       SPIR-V disassembly for {{.*}}vert.spvasm{{$}}
+; CC-VERT-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
+; CC-VERT:       {{^Hash for vertex stage cache lookup:}} [[vert_cache_hash]]{{$}}
+
+
+; Test 2: Create a cache file with two inputs. Check that both ELFs are present in the cache file.
+; RUN: cache-creator %t.vert.elf %t.frag.elf --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 \
+; RUN:               -o %t.vert-frag.bin --verbose > %t.vert-frag.cc.log 2>&1 \
+; RUN:   && cache-info %t.vert-frag.bin --elf-source-dir=%T > %t.vert-frag.ci.log 2>&1 \
+; RUN:   && cat %t.vert-frag.cc.log %t.vert-frag.ci.log %t.vert.amdllpc.log %t.frag.amdllpc.log \
 ; RUN:   | FileCheck --check-prefix=CC-TWO %s
-; CC-TWO:       {{^Num}} inputs: 2, anticipated cache size: [[two_cache_size:[0-9]+]]{{$}}
-; CC-TWO-NEXT:  {{^Read:}} {{.*}}.vert.elf{{$}}
-; CC-TWO:       {{^Read:}} {{.*}}.frag.elf{{$}}
-; CC-TWO:       {{^Num}} entries written: 2, actual cache size: [[two_cache_size]] B{{$}}
-; CC-TWO-LABEL: {{^Cache}} successfully written to: {{.*}}.vert-frag.bin{{$}}
+; Part 2a: Check cache-creator output.
+; CC-TWO:       {{^Num}} inputs: 2, anticipated cache size: [[#two_cache_size:]]{{$}}
+; CC-TWO-NEXT:  {{^Read:}} [[vert_elf_path:.*\.vert\.elf]]{{$}}
+; CC-TWO:       {{^Read:}} [[frag_elf_path:.*\.frag\.elf]]{{$}}
+; CC-TWO:       {{^Num}} entries written: 2, actual cache size: [[#two_cache_size]] B{{$}}
+; CC-TWO:       {{^Cache}} successfully written to: [[cache_file_path:.*\.vert-frag\.bin]]{{$}}
+;
+; Part 2b: Check cache-info output.
+; CC-TWO:       {{^Read:}} {{.*}}.vert-frag.bin, [[#two_cache_size]] B{{$}}
+;
+; CC-TWO-LABEL: {{^===}} Vulkan Pipeline Cache Header
+; CC-TWO-NEXT:  {{^header length:}} [[#vk_header_len:32]]{{$}}
+; CC-TWO:       {{^trailing space:}} 0{{$}}
+;
+; CC-TWO-LABEL: {{^===}} Pipeline Binary Cache Private Header
+; CC-TWO-NEXT:  {{^header length:}} [[#pbc_header_len:20]]{{$}}
+; CC-TWO:       {{^content size:}} [[#two_cache_size - vk_header_len - pbc_header_len]]{{$}}
+;
+; CC-TWO-LABEL: {{^===}} Cache Content Info
+; CC-TWO-NEXT:  {{^total num entries:}} 2{{$}}
+; CC-TWO-NEXT:  {{^entry header length:}} [[#entry_header_len:24]]{{$}}
+;
+; CC-TWO-LABEL: {{^}} *** Entry 0 ***
+; CC-TWO-NEXT:  {{^}} hash ID: [[vert_cache_hash:([0-9a-f]{2} ?){16}]]{{$}}
+; CC-TWO-NEXT:  {{^}} data size: [[#vert_entry_data_size:]]{{$}}
+; CC-TWO-NEXT:  {{^}} calculated MD5 sum: {{[0-9a-f]{32}$}}
+; CC-TWO-NEXT:  {{^}} matched source file: [[vert_elf_path]]{{$}}
+;
+; CC-TWO-LABEL: {{^}} *** Entry 1 ***
+; CC-TWO-NEXT:  {{^}} hash ID: [[frag_cache_hash:([0-9a-f]{2} ?){16}]]{{$}}
+; CC-TWO-NEXT:  {{^}} data size: [[#two_cache_size - vk_header_len - pbc_header_len - entry_header_len - vert_entry_data_size - entry_header_len]]{{$}}
+; CC-TWO-NEXT:  {{^}} calculated MD5 sum: {{[0-9a-f]{32}$}}
+; CC-TWO-NEXT:  {{^}} matched source file: [[frag_elf_path]]{{$}}
+;
+; Part 2c: Check amdllpc output to see that the entry hash IDs from 2b match the compiler vertex and fragment cache hashes.
+; CC-TWO:       SPIR-V disassembly for {{.*}}vert.spvasm{{$}}
+; CC-TWO-LABEL: {{// LLPC}} calculated hash results (graphics pipeline)
+; CC-TWO:       {{^Hash for vertex stage cache lookup:}} [[vert_cache_hash]]{{$}}
+;
+; CC-TWO:       SPIR-V disassembly for {{.*}}frag.spvasm{{$}}
+; CC-TWO-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
+; CC-TWO:       {{^Hash for fragment stage cache lookup:}} [[frag_cache_hash]]{{$}}
+
 
 ; Test 3: Create a cache file with one input repeated twice.
 ;         In this case, we simply add it twice and do not attempt to de-duplicate inputs.
-; RUN: cache-creator %t.vert.elf %t.vert.elf --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 -o %t.vert-vert.bin --verbose \
-; RUN:   | FileCheck --check-prefix=CC-DUP %s
-; CC-DUP:       {{^Num}} inputs: 2, anticipated cache size: [[dup_cache_size:[0-9]+]]{{$}}
-; CC-DUP-NEXT:  {{^Read:}} {{.*}}.vert.elf{{$}}
-; CC-DUP:       {{^Read:}} {{.*}}.vert.elf{{$}}
-; CC-DUP:       {{^Num}} entries written: 2, actual cache size: [[dup_cache_size]] B{{$}}
-; CC-DUP-LABEL: {{^Cache}} successfully written to: {{.*}}.vert-vert.bin{{$}}
+; RUN: cache-creator %t.vert.elf %t.vert.elf --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 \
+; RUN:               -o %t.vert-vert.bin --verbose > %t.vert-vert.cc.log 2>&1 \
+; RUN:   && cache-info %t.vert-vert.bin --elf-source-dir=%T > %t.vert-vert.ci.log 2>&1 \
+; RUN:   && cat %t.vert-vert.cc.log %t.vert-vert.ci.log %t.vert.amdllpc.log | FileCheck --check-prefix=CC-DUP %s
+; Part 3a: Check cache-creator output.
+; CC-DUP:       {{^Num}} inputs: 2, anticipated cache size: [[#dup_cache_size:]]{{$}}
+; CC-DUP-NEXT:  {{^Read:}} [[vert_elf_path:.*\.vert\.elf]]{{$}}
+; CC-DUP:       {{^Read:}} [[vert_elf_path]]{{$}}
+; CC-DUP:       {{^Num}} entries written: 2, actual cache size: [[#dup_cache_size]] B{{$}}
+; CC-DUP:       {{^Cache}} successfully written to: [[cache_file_path:.*\.vert-vert\.bin]]{{$}}
+;
+; Part 3b: Check cache-info output.
+; CC-DUP:       {{^Read:}} [[cache_file_path]], [[#dup_cache_size]] B{{$}}
+;
+; CC-DUP-LABEL: {{^===}} Cache Content Info
+; CC-DUP-NEXT:  {{^total num entries:}} 2{{$}}
+;
+; CC-DUP-LABEL: {{^}} *** Entry 0 ***
+; CC-DUP-NEXT:  {{^}} hash ID: [[vert_cache_hash:([0-9a-f]{2} ?){16}]]{{$}}
+; CC-DUP-NEXT:  {{^}} data size: [[#vert_entry_data_size:]]{{$}}
+; CC-DUP-NEXT:  {{^}} calculated MD5 sum: [[vert_md5_sum:[0-9a-f]{32}]]{{$}}
+; CC-DUP-NEXT:  {{^}} matched source file: [[vert_elf_path]]{{$}}
+;
+; CC-DUP-LABEL: {{^}} *** Entry 1 ***
+; CC-DUP-NEXT:  {{^}} hash ID: [[vert_cache_hash]]{{$}}
+; CC-DUP-NEXT:  {{^}} data size: [[#vert_entry_data_size]]{{$}}
+; CC-DUP-NEXT:  {{^}} calculated MD5 sum: [[vert_md5_sum]]{{$}}
+; CC-DUP-NEXT:  {{^}} matched source file: [[vert_elf_path]]{{$}}
+;
+; Part 3c: Check amdllpc output to see that the entry hash ID from 2b matches the compiler vertex cache hash.
+; CC-DUP:       SPIR-V disassembly for {{.*}}vert.spvasm{{$}}
+; CC-DUP-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
+; CC-DUP:       {{^Hash for vertex stage cache lookup:}} [[vert_cache_hash]]{{$}}
+
 
 ;--- vert.spvasm
 ; SPIR-V


### PR DESCRIPTION
Use cache-info to make sure that cache files created with cache-creator
have expected contents and structure. Make sure that all cache file bytes
are accounted for. Check that cache hashes match those printed by amdllpc.

Add missing lines to cache-info output.