### PR TITLE
Remove unnecessary move and fix a build failure

### DIFF
--- a/tools/cache_creator/cache_info.cpp
+++ b/tools/cache_creator/cache_info.cpp
@@ -155,7 +155,7 @@ llvm::Error
 CacheBlobInfo::readBinaryCacheEntriesInfo(llvm::SmallVectorImpl<BinaryCacheEntryInfo> &entriesInfoOut) const {
   auto contentOffsetOrErr = getCacheContentOffset();
   if (auto err = contentOffsetOrErr.takeError())
-    return std::move(err);
+    return err;
 
   constexpr size_t EntrySize = sizeof(vk::BinaryCacheEntry);
   const uint8_t *const blobStart = reinterpret_cast<const uint8_t *>(m_cacheBlob.getBufferStart());


### PR DESCRIPTION
This silences a pessimizing move warning treated as an error.
Sample CI build failure caused by this:
https://github.com/GPUOpen-Drivers/llpc/runs/2287221496?check_suite_focus=true.