### PR TITLE
Increase Dynamic Uniform Buffer limit.

### DIFF
--- a/icd/api/include/vk_defines.h
+++ b/icd/api/include/vk_defines.h
@@ -180,7 +180,7 @@ namespace vk
     static const uint32_t InvalidPalDeviceMask = 1 << (MaxPalDevices+1);
 
     // Maximum number of dynamic descriptors
-    static const uint32_t MaxDynamicUniformDescriptors = 8;
+    static const uint32_t MaxDynamicUniformDescriptors = 32;
     static const uint32_t MaxDynamicStorageDescriptors = 8;
     static const uint32_t MaxDynamicDescriptors = MaxDynamicUniformDescriptors + MaxDynamicStorageDescriptors;
 


### PR DESCRIPTION
For some developers, the higher Dynamic Uniform Buffer Object Limit is appealing. We understand that the ICD supports it, however if this is limited to certain GPU families, could we enable it one GFX9 and above?