### PR TITLE
Set pDataSize equal to privateDataSize + bytesWritten

### DIFF
--- a/icd/api/vk_pipeline_cache.cpp
+++ b/icd/api/vk_pipeline_cache.cpp
@@ -446,8 +446,9 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPipelineCacheData(
             {
                 void* pPrivateData = Util::VoidPtrInc(pData, headerBytesWritten);
                 result = pCache->GetData(pPrivateData, &privateDataSize);
-                *pDataSize = privateDataSize + headerBytesWritten;
             }
+            // set pDataSize, privateDataSize can be 0.
+            *pDataSize = privateDataSize + headerBytesWritten;
         }
     }
 


### PR DESCRIPTION
On success in vkGetPipelineCacheData, set pDataSize even if the privateDataSize is zero. It will be equal to byteswritten when
privateDataSize is zero.