### PR TITLE
Avoid overflow in vk::utils::GetTimeNano()

### DIFF
--- a/icd/api/include/vk_utils.h
+++ b/icd/api/include/vk_utils.h
@@ -135,8 +135,8 @@ namespace utils
 // Get time in nano seconds
 VK_INLINE uint64_t GetTimeNano()
 {
-    return (static_cast<Pal::uint64>(Util::GetPerfCpuTime()) * NANOSECONDS_IN_A_SECOND) /
-        static_cast<Pal::uint64>(Util::GetPerfFrequency());
+    return static_cast<Pal::uint64>(Util::GetPerfCpuTime()) *
+        (NANOSECONDS_IN_A_SECOND / static_cast<Pal::uint64>(Util::GetPerfFrequency()));
 }
 
 // =====================================================================================================================

--- a/icd/api/include/vk_utils.h
+++ b/icd/api/include/vk_utils.h
@@ -131,12 +131,9 @@ typedef VkAccessFlags2KHR        AccessFlags;
 namespace utils
 {
 
-// =====================================================================================================================
-// Get time in nano seconds
-VK_INLINE uint64_t GetTimeNano()
+VK_INLINE uint64_t TicksToNano(uint64_t ticks)
 {
-    return static_cast<Pal::uint64>(Util::GetPerfCpuTime()) *
-        (NANOSECONDS_IN_A_SECOND / static_cast<Pal::uint64>(Util::GetPerfFrequency()));
+    return (ticks * NANOSECONDS_IN_A_SECOND) / static_cast<Pal::uint64>(Util::GetPerfFrequency());
 }
 
 // =====================================================================================================================

--- a/icd/api/vk_compute_pipeline.cpp
+++ b/icd/api/vk_compute_pipeline.cpp
@@ -126,7 +126,7 @@ VkResult ComputePipeline::Create(
     const VkAllocationCallbacks*            pAllocator,
     VkPipeline*                             pPipeline)
 {
-    uint64 startTime = vk::utils::GetTimeNano();
+    uint64 startTimeTicks = Util::GetPerfCpuTime();
 
     // Setup PAL create info from Vulkan inputs
     size_t                          pipelineBinarySizes[MaxPalDevices] = {};
@@ -327,7 +327,8 @@ VkResult ComputePipeline::Create(
 
     if (result == VK_SUCCESS)
     {
-        uint64_t duration = vk::utils::GetTimeNano() - startTime;
+        uint64_t durationTicks = Util::GetPerfCpuTime() - startTimeTicks;
+        uint64_t duration = vk::utils::TicksToNano(durationTicks);
         binaryCreateInfo.pipelineFeedback.feedbackValid = true;
         binaryCreateInfo.pipelineFeedback.duration = duration;
         pDefaultCompiler->SetPipelineCreationFeedbackInfo(

--- a/icd/api/vk_graphics_pipeline.cpp
+++ b/icd/api/vk_graphics_pipeline.cpp
@@ -59,7 +59,7 @@ VkResult GraphicsPipeline::Create(
     const VkAllocationCallbacks*            pAllocator,
     VkPipeline*                             pPipeline)
 {
-    uint64 startTime = vk::utils::GetTimeNano();
+    uint64 startTimeTicks = Util::GetPerfCpuTime();
 
     // Parse the create info and build patched AMDIL shaders
     GraphicsPipelineObjectCreateInfo objectCreateInfo                   = {};
@@ -385,7 +385,8 @@ VkResult GraphicsPipeline::Create(
     }
     if (result == VK_SUCCESS)
     {
-        uint64_t duration = vk::utils::GetTimeNano() - startTime;
+        uint64_t durationTicks = Util::GetPerfCpuTime() - startTimeTicks;
+        uint64_t duration = vk::utils::TicksToNano(durationTicks);
         binaryCreateInfo.pipelineFeedback.feedbackValid = true;
         binaryCreateInfo.pipelineFeedback.duration = duration;
         pDefaultCompiler->SetPipelineCreationFeedbackInfo(


### PR DESCRIPTION
Changing the order of operations in GetNanoTime() avoids an overflow that has been observed during some of our tests.