### PR TITLE
Update cache creator test

### DIFF
--- a/tools/cache_creator/test/RunLitCommands.spvasm
+++ b/tools/cache_creator/test/RunLitCommands.spvasm
@@ -13,7 +13,7 @@
 ; CHECK-OBJDUMP: Registered Targets
 
 ; RUN: llvm-readelf --version | FileCheck -check-prefix=CHECK-READELF %s
-; CHECK-READELF: Registered Targets
+; CHECK-READELF: Default target:
 
 ; SPIR-V
 ; Version: 1.0


### PR DESCRIPTION
The test needs to be updated because llvm-read-elf changed its output
when run with `--version`.  It no longer output the registered targets.
Since the test is only interested in making sure the exe ran, I updated
the test to look for different output.