### PR TITLE
Add cmake flag to enable all tests

### DIFF
--- a/cmake/XglOptions.cmake
+++ b/cmake/XglOptions.cmake
@@ -42,6 +42,9 @@ macro(xgl_options)
 
     option(XGL_BUILD_NAVI23 "Build open source vulkan for Navi23" ON)
 
+    option(XGL_BUILD_TESTS "Build all tests?" OFF)
+
+    # Deprecated, use XGL_BUILD_TESTS instead.
     option(XGL_BUILD_LIT "Build with Lit test?" OFF)
 
     option(XGL_BUILD_CACHE_CREATOR "Build cache-creator tools?" OFF)

--- a/cmake/XglOverrides.cmake
+++ b/cmake/XglOverrides.cmake
@@ -185,8 +185,12 @@ macro(xgl_overrides_vkgc)
     set(LLPC_CLIENT_INTERFACE_MAJOR_VERSION ${ICD_LLPC_CLIENT_MAJOR_VERSION} CACHE STRING "${PROJECT_NAME} override." FORCE)
 
     if(ICD_BUILD_LLPC)
+        set(LLPC_BUILD_TESTS ${XGL_BUILD_TESTS} CACHE BOOL "${PROJECT_NAME} override." FORCE)
 
         set(LLPC_BUILD_LIT ${XGL_BUILD_LIT} CACHE BOOL "${PROJECT_NAME} override." FORCE)
+        if(XGL_BUILD_LIT)
+            message(DEPRECATION "XGL_BUILD_LIT is deprecated, use XGL_BUILD_TESTS instead")
+        endif()
 
         set(LLPC_BUILD_NAVI12 ${XGL_BUILD_NAVI12} CACHE BOOL "${PROJECT_NAME} override." FORCE)
 

--- a/tools/cache_creator/CMakeLists.txt
+++ b/tools/cache_creator/CMakeLists.txt
@@ -75,8 +75,8 @@ target_link_libraries(cache-info PRIVATE cache_creator_lib)
 # Build cache creator tools whenever we build XGL.
 add_dependencies(xgl cache-creator cache-info)
 
-if(XGL_BUILD_LIT)
-    message(STATUS "Building cache creator LIT tests")
+if(XGL_BUILD_TESTS OR XGL_BUILD_LIT)
+    message(STATUS "Building cache creator tests")
     set(CACHE_CREATOR_TOOLS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
     add_subdirectory(test "${CMAKE_CURRENT_BINARY_DIR}/test/cache-creator/lit")
     add_subdirectory(unittests "${CMAKE_CURRENT_BINARY_DIR}/test/cache-creator/unittests")


### PR DESCRIPTION
`XGL_BUILD_TESTS` better reflects that different kinds of test get
built (not just LIT), and matches the `LLPC_BUILD_TESTS` flag.

The new flag deprecates `XGL_BUILD_LIT`.