### PR TITLE
Write immutable samplers to descriptor set under and option

### DIFF
--- a/icd/api/include/vk_descriptor_set.h
+++ b/icd/api/include/vk_descriptor_set.h
@@ -125,6 +125,8 @@ protected:
         DescriptorAddr*             pBaseAddrs,
         void*                       pAllocHandle);
 
+    void WriteImmutableSamplers();
+
     void Reset();
 
     void* AllocHandle() const

--- a/icd/api/include/vk_device.h
+++ b/icd/api/include/vk_device.h
@@ -141,7 +141,8 @@ public:
             uint32                robustBufferAccessExtended    : 1;
             uint32                robustImageAccessExtended     : 1;
             uint32                nullDescriptorExtended        : 1;
-            uint32                reserved                      : 24;
+            uint32                mustWriteImmutableSamplers    : 1;
+            uint32                reserved                      : 23;
         };
 
         uint32 u32All;
@@ -631,6 +632,10 @@ public:
 
     bool UseCompactDynamicDescriptors() const
         { return !GetRuntimeSettings().enableRelocatableShaders && !GetEnabledFeatures().robustBufferAccess;}
+
+
+    bool MustWriteImmutableSamplers() const
+        { return GetEnabledFeatures().mustWriteImmutableSamplers; }
 
     bool SupportDepthStencilResolve() const
     {

--- a/icd/api/vk_descriptor_pool.cpp
+++ b/icd/api/vk_descriptor_pool.cpp
@@ -347,6 +347,10 @@ VkResult DescriptorPool::AllocDescriptorSets(
                         setGpuMemOffset,
                         m_addresses,
                         pSetAllocHandle);
+                    if (m_pDevice->MustWriteImmutableSamplers())
+                    {
+                        pSet->WriteImmutableSamplers();
+                    }
                 }
                 else
                 {

--- a/icd/api/vk_descriptor_set.cpp
+++ b/icd/api/vk_descriptor_set.cpp
@@ -104,7 +104,7 @@ void DescriptorSet<numPalDevices>::WriteImmutableSamplers()
             {
                 uint32_t* pSamplerDesc = Layout()->Info().imm.pImmutableSamplerData + bindingInfo.imm.dwOffset;
                 uint32_t* pDestAddr = StaticCpuAddress(deviceIdx) + Layout()->GetDstStaOffset(bindingInfo, 0);
-                memcpy(pDestAddr, pSamplerDesc, sizeof(uint) * bindingInfo.imm.dwSize);
+                memcpy(pDestAddr, pSamplerDesc, sizeof(uint32) * bindingInfo.imm.dwSize);
             }
         }
     }

--- a/icd/api/vk_descriptor_set.cpp
+++ b/icd/api/vk_descriptor_set.cpp
@@ -90,6 +90,27 @@ void DescriptorSet<numPalDevices>::Reassign(
 }
 
 // =====================================================================================================================
+// Writes the immutable samplers in the layout to memory.
+template <uint32_t numPalDevices>
+void DescriptorSet<numPalDevices>::WriteImmutableSamplers()
+{
+    for (uint32_t deviceIdx = 0; deviceIdx < numPalDevices; deviceIdx++)
+    {
+        for (uint32_t bindingIndex = 0; bindingIndex < Layout()->Info().count; ++bindingIndex)
+        {
+            const DescriptorSetLayout::BindingInfo& bindingInfo = Layout()->Binding(bindingIndex);
+
+            if (bindingInfo.imm.dwSize != 0)
+            {
+                uint32_t* pSamplerDesc = Layout()->Info().imm.pImmutableSamplerData + bindingInfo.imm.dwOffset;
+                uint32_t* pDestAddr = StaticCpuAddress(deviceIdx) + Layout()->GetDstStaOffset(bindingInfo, 0);
+                memcpy(pDestAddr, pSamplerDesc, sizeof(uint) * bindingInfo.imm.dwSize);
+            }
+        }
+    }
+}
+
+// =====================================================================================================================
 // Resets a DescriptorSet to an intial state
 template <uint32_t numPalDevices>
 void DescriptorSet<numPalDevices>::Reset()
@@ -1049,6 +1070,9 @@ template
 void DescriptorSet<1>::Reset();
 
 template
+void DescriptorSet<1>::WriteImmutableSamplers();
+
+template
 DescriptorSet<2>::DescriptorSet(uint32_t heapIndex);
 
 template
@@ -1060,6 +1084,9 @@ void DescriptorSet<2>::Reassign(
 
 template
 void DescriptorSet<2>::Reset();
+
+template
+void DescriptorSet<2>::WriteImmutableSamplers();
 
 template
 DescriptorSet<3>::DescriptorSet(uint32_t heapIndex);
@@ -1075,6 +1102,9 @@ template
 void DescriptorSet<3>::Reset();
 
 template
+void DescriptorSet<3>::WriteImmutableSamplers();
+
+template
 DescriptorSet<4>::DescriptorSet(uint32_t heapIndex);
 
 template
@@ -1086,5 +1116,8 @@ void DescriptorSet<4>::Reassign(
 
 template
 void DescriptorSet<4>::Reset();
+
+template
+void DescriptorSet<4>::WriteImmutableSamplers();
 
 } // namespace vk

--- a/icd/api/vk_device.cpp
+++ b/icd/api/vk_device.cpp
@@ -312,6 +312,15 @@ Device::Device(
         m_enabledFeatures.robustBufferAccess = false;
     }
 
+    if (RuntimeSettings().enableRelocatableShaders)
+    {
+        m_enabledFeatures.mustWriteImmutableSamplers = true;
+    }
+    else
+    {
+        m_enabledFeatures.mustWriteImmutableSamplers = false;
+    }
+
     m_enabledFeatures.scalarBlockLayout = false;
 
     m_enabledFeatures.attachmentFragmentShadingRate = false;


### PR DESCRIPTION
This has two places where the immutable samplers could be written.  This
is not the final code.  It is just something to start discussion.  Let
me know what you think.

Discussion for https://github.com/GPUOpen-Drivers/xgl/issues/128.