### PR TITLE
Add option to replace both shaders and pipelines.

### DIFF
--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -360,7 +360,8 @@ VkResult PipelineCompiler::BuildShaderModule(
     Util::MetroHash64::Hash(reinterpret_cast<const uint8_t*>(pCode), codeSize, hash.bytes);
     bool findReplaceShader = false;
 
-    if (pSettings->shaderReplaceMode == ShaderReplaceShaderHash)
+    if ((pSettings->shaderReplaceMode == ShaderReplaceShaderHash) ||
+        (pSettings->shaderReplaceMode == ShaderReplaceShaderHashPipelineBinaryHash))
     {
         size_t replaceCodeSize = 0;
         void* pReplaceCode = nullptr;
@@ -406,7 +407,7 @@ void PipelineCompiler::FreeShaderModule(
 }
 
 // =====================================================================================================================
-// Replaces pipeline binary from external replacment file (<pipeline_name>_repalce.elf)
+// Replaces pipeline binary from external replacement file (<pipeline_name>_replace.elf)
 template<class PipelineBuildInfo>
 bool PipelineCompiler::ReplacePipelineBinary(
         const PipelineBuildInfo* pPipelineBuildInfo,
@@ -725,7 +726,8 @@ VkResult PipelineCompiler::CreateGraphicsPipelineBinary(
         &pCreateInfo->pipelineInfo.fs,
     };
 
-    if (settings.shaderReplaceMode == ShaderReplacePipelineBinaryHash)
+    if ((settings.shaderReplaceMode == ShaderReplacePipelineBinaryHash) ||
+        (settings.shaderReplaceMode == ShaderReplaceShaderHashPipelineBinaryHash))
     {
         if (ReplacePipelineBinary(&pCreateInfo->pipelineInfo, pPipelineBinarySize, ppPipelineBinary, pipelineHash))
         {
@@ -928,7 +930,8 @@ VkResult PipelineCompiler::CreateComputePipelineBinary(
     ShaderModuleHandle shaderModuleReplaceHandle = {};
     bool shaderModuleReplaced = false;
 
-    if (settings.shaderReplaceMode == ShaderReplacePipelineBinaryHash)
+    if ((settings.shaderReplaceMode == ShaderReplacePipelineBinaryHash) ||
+        (settings.shaderReplaceMode == ShaderReplaceShaderHashPipelineBinaryHash))
     {
         if (ReplacePipelineBinary(&pCreateInfo->pipelineInfo, pPipelineBinarySize, ppPipelineBinary, pipelineHash))
         {

--- a/icd/settings/settings_xgl.json
+++ b/icd/settings/settings_xgl.json
@@ -1118,6 +1118,11 @@
             "Name": "ShaderReplaceShaderISA",
             "Value": 4,
             "Description": "Enable replace ISA shader in the pipeline, For every pipeline in the ShaderReplacementPipelineHashs, would find if there is a file named 0xAAA_replace.txt under ShaderReplacementDir, would be loaded for the replacement the replace shader look like this  *----offset: ISACODE----* 848:0x7E120303   1480:0x7E1E0303  2592:0x7E0E030E"
+          },
+          {
+            "Name": "ShaderReplaceShaderHashPipelineBinaryHash",
+            "Value": 5,
+            "Description": "Enable both shader hash based shader replacement and pipeline binary hash based pipeline binary replacement. In cases where both a pipeline and one or more of its shaders are replaced, the replacement shader will take precedence and will potentially change the hash of the pipeline. The pipeline will only be replaced if the pipeline replacement file has the new hash."
           }
         ],
         "Name": "ShaderReplaceMode"


### PR DESCRIPTION
This option basically combines the `ShaderReplaceShaderHash` and `ShaderReplacePipelineBinaryHash` options. 

Both shaders and pipeline binaries are replaced when the replacement files are found. ~In cases where both a pipeline and one or more of its shaders are replaced, the replacement pipeline takes precedence over the replacement shader.~ In cases where both a pipeline and one or more of its shaders are replaced, the replacement shader will take precedence and will potentially change the hash of the pipeline. The pipeline will only be replaced if the pipeline replacement file has the new hash.