### PR TITLE
Remove shader module opt

### DIFF
--- a/icd/api/compiler_solution_llpc.cpp
+++ b/icd/api/compiler_solution_llpc.cpp
@@ -140,7 +140,9 @@ VkResult CompilerSolutionLlpc::BuildShaderModule(
 
     auto pPipelineCompiler = m_pPhysicalDevice->GetCompiler();
     pPipelineCompiler->ApplyPipelineOptions(pDevice, 0, &moduleInfo.options.pipelineOptions);
+    #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 50
     moduleInfo.options.enableOpt = (flags & VK_SHADER_MODULE_ENABLE_OPT_BIT) ? true : false;
+    #endif
 
     Vkgc::Result llpcResult = m_pLlpc->BuildShaderModule(&moduleInfo, &buildOut);
 

--- a/icd/api/include/vk_shader.h
+++ b/icd/api/include/vk_shader.h
@@ -34,8 +34,10 @@
 
 namespace Pal { enum class ResourceMappingNodeType : Pal::uint32; }
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 50
 // NOTE: Internal shader module create flag, please modify it if it conflict with vulkan header files.
 #define VK_SHADER_MODULE_ENABLE_OPT_BIT    0x40000000u
+#endif
 
 namespace vk
 {

--- a/icd/make/importdefs
+++ b/icd/make/importdefs
@@ -36,7 +36,7 @@ ICD_GPUOPEN_CLIENT_MINOR_VERSION = 0
 
 # This will become the value of LLPC_CLIENT_INTERFACE_MAJOR_VERSION if ICD_BUILD_LLPC=1.  It describes the version of the
 # interface version of LLPC that the ICD supports.
-ICD_LLPC_CLIENT_MAJOR_VERSION = 49
+ICD_LLPC_CLIENT_MAJOR_VERSION = 50
 
 # When ICD_LLPC_CLIENT_MAJOR_VERSION >= 39, Set ENABLE_VKGC to 1 to use Vkgc namespace instead of Llpc namespace in ICD
 ENABLE_VKGC=1


### PR DESCRIPTION
This was removed from LLPC in https://github.com/GPUOpen-Drivers/llpc/pull/1413.

Also bump the LLPC client interface version.