### PR TITLE
Update new members of SamplerYCbCrConversionMetaData

### DIFF
--- a/icd/api/include/vk_sampler.h
+++ b/icd/api/include/vk_sampler.h
@@ -31,6 +31,7 @@
 #include "include/vk_defines.h"
 #include "include/vk_dispatch.h"
 #include "include/vk_utils.h"
+#include "include/vk_sampler_ycbcr_conversion.h"
 
 #include "palUtil.h"
 
@@ -70,27 +71,41 @@ public:
         return m_multiPlaneCount;
     }
 
+    Vkgc::SamplerYCbCrConversionMetaData* GetYCbCrConversionMetaData()
+    {
+        return m_pYcbcrConversionMetaData;
+    }
+
+    bool IsYCbCrConversionMetaDataUpdated(const Vkgc::SamplerYCbCrConversionMetaData* pMetaData)
+    {
+        return ((m_pYcbcrConversionMetaData->word4.u32All != pMetaData->word4.u32All) ||
+                (m_pYcbcrConversionMetaData->word5.u32All != pMetaData->word5.u32All));
+    }
+
 protected:
     Sampler(
-        uint64_t apiHash,
-        bool     isYCbCrSampler,
-        uint32_t multiPlaneCount,
-        uint32_t borderColorPaletteIndex)
+        uint64_t                              apiHash,
+        bool                                  isYCbCrSampler,
+        uint32_t                              multiPlaneCount,
+        uint32_t                              borderColorPaletteIndex,
+        Vkgc::SamplerYCbCrConversionMetaData* pYcbcrConversionMetaData)
         :
         m_apiHash(apiHash),
         m_isYCbCrSampler(isYCbCrSampler),
         m_multiPlaneCount(multiPlaneCount),
-        m_borderColorPaletteIndex(borderColorPaletteIndex)
+        m_borderColorPaletteIndex(borderColorPaletteIndex),
+        m_pYcbcrConversionMetaData(pYcbcrConversionMetaData)
     {
     }
 
     static uint64_t BuildApiHash(
         const VkSamplerCreateInfo* pCreateInfo);
 
-    const uint64_t          m_apiHash;
-    const bool              m_isYCbCrSampler;
-    const uint32_t          m_multiPlaneCount;
-    const uint32_t          m_borderColorPaletteIndex;
+    const uint64_t                        m_apiHash;
+    const bool                            m_isYCbCrSampler;
+    const uint32_t                        m_multiPlaneCount;
+    const uint32_t                        m_borderColorPaletteIndex;
+    Vkgc::SamplerYCbCrConversionMetaData* m_pYcbcrConversionMetaData;
 
 private:
     PAL_DISALLOW_COPY_AND_ASSIGN(Sampler);

--- a/icd/api/include/vk_sampler_ycbcr_conversion.h
+++ b/icd/api/include/vk_sampler_ycbcr_conversion.h
@@ -65,6 +65,8 @@ public:
 
     Vkgc::SamplerYCbCrConversionMetaData* GetMetaData() {return &m_metaData;}
 
+    void SetExtent(uint32 width, uint32 height, uint32 depth);
+
 protected:
     SamplerYcbcrConversion(const VkSamplerYcbcrConversionCreateInfo* pCreateInfo, const RuntimeSettings& settings);
 

--- a/icd/api/vk_descriptor_set_layout.cpp
+++ b/icd/api/vk_descriptor_set_layout.cpp
@@ -415,7 +415,20 @@ void DescriptorSetLayout::ConvertImmutableInfo(
                         // Copy the YCbCrMetaData
                         const void* pYCbCrMetaData = Util::VoidPtrInc(pSamplerDesc, descSizeInDw * sizeof(uint32_t));
                         void* pImmutableYCbCrMetaDataDestAddr = Util::VoidPtrInc(pDestAddr, descSizeInDw * sizeof(uint32_t));
-                        memcpy(pImmutableYCbCrMetaDataDestAddr, pYCbCrMetaData, yCbCrMetaDataSizeInDW * sizeof(uint32_t));
+                        Sampler* pSampler = Sampler::ObjectFromHandle(pBindingInfo->pImmutableSamplers[i]);
+                        Vkgc::SamplerYCbCrConversionMetaData* pCurrentYCbCrMetaData = pSampler->GetYCbCrConversionMetaData();
+
+                        if (pSampler->IsYCbCrConversionMetaDataUpdated(
+                                              static_cast<const Vkgc::SamplerYCbCrConversionMetaData*>(pYCbCrMetaData)))
+                        {
+                            memcpy(pImmutableYCbCrMetaDataDestAddr, pCurrentYCbCrMetaData,
+                                                                    yCbCrMetaDataSizeInDW * sizeof(uint32_t));
+                        }
+                        else
+                        {
+                            memcpy(pImmutableYCbCrMetaDataDestAddr, pYCbCrMetaData,
+                                                                    yCbCrMetaDataSizeInDW * sizeof(uint32_t));
+                        }
                     }
                 }
             }

--- a/icd/api/vk_image_view.cpp
+++ b/icd/api/vk_image_view.cpp
@@ -496,6 +496,13 @@ VkResult ImageView::Create(
             imageViewUsage = pUsageInfo->usage;
             break;
         }
+        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
+        {
+            const auto* pSamplerYcbcrConversionInfo = reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(pHeader);
+            SamplerYcbcrConversion::ObjectFromHandle(pSamplerYcbcrConversionInfo->conversion)->SetExtent(
+                imageInfo.extent.width, imageInfo.extent.height, imageInfo.arraySize);
+            break;
+        }
         default:
             // Skip any unknown extension structures
             break;

--- a/icd/api/vk_sampler.cpp
+++ b/icd/api/vk_sampler.cpp
@@ -83,6 +83,8 @@ uint64_t Sampler::BuildApiHash(
                 hasher.Update(pSamplerYCbCrConversionMetaData->word1.u32All);
                 hasher.Update(pSamplerYCbCrConversionMetaData->word2.u32All);
                 hasher.Update(pSamplerYCbCrConversionMetaData->word3.u32All);
+                hasher.Update(pSamplerYCbCrConversionMetaData->word4.u32All);
+                hasher.Update(pSamplerYCbCrConversionMetaData->word5.u32All);
 
                 break;
             case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO:
@@ -258,9 +260,10 @@ VkResult Sampler::Create(
     uint32_t multiPlaneCount = pSamplerYCbCrConversionMetaData != nullptr ? pSamplerYCbCrConversionMetaData->word1.planes : 1;
 
     VK_PLACEMENT_NEW (pMemory) Sampler(apiHash,
-                                      (pSamplerYCbCrConversionMetaData != nullptr),
-                                      multiPlaneCount,
-                                      samplerInfo.borderColorPaletteIndex);
+                                       (pSamplerYCbCrConversionMetaData != nullptr),
+                                       multiPlaneCount,
+                                       samplerInfo.borderColorPaletteIndex,
+                                       pSamplerYCbCrConversionMetaData);
 
     *pSampler = Sampler::HandleFromVoidPointer(pMemory);
 

--- a/icd/api/vk_sampler_ycbcr_conversion.cpp
+++ b/icd/api/vk_sampler_ycbcr_conversion.cpp
@@ -209,6 +209,21 @@ SamplerYcbcrConversion::SamplerYcbcrConversion(
     m_metaData.word2.bitCounts.yBitCount = yuvFormatInfo.bitCount[1];
     m_metaData.word2.bitCounts.zBitCount = yuvFormatInfo.bitCount[2];
     m_metaData.word2.bitCounts.wBitCount = yuvFormatInfo.bitCount[3];
+
+    m_metaData.word4.lumaWidth  = 0;
+    m_metaData.word4.lumaHeight = 0;
+    m_metaData.word5.lumaDepth  = 0;
+}
+
+// =====================================================================================================================
+void SamplerYcbcrConversion::SetExtent(
+    uint32 width,
+    uint32 height,
+    uint32 depth)
+{
+    m_metaData.word4.lumaWidth  = width;
+    m_metaData.word4.lumaHeight = height;
+    m_metaData.word5.lumaDepth  = depth;
 }
 
 namespace entry


### PR DESCRIPTION
This fix is used to support VK_EXT_ycbcr_image_arrays extension
implementation. Which is used to store actual luma size of ycbcr image.