### PR TITLE
Fix writing of immutable samplers

### DIFF
--- a/icd/api/vk_device.cpp
+++ b/icd/api/vk_device.cpp
@@ -310,7 +310,7 @@ Device::Device(
         m_enabledFeatures.robustBufferAccess = false;
     }
 
-    if (RuntimeSettings().enableRelocatableShaders)
+    if (m_settings.enableRelocatableShaders)
     {
         m_enabledFeatures.mustWriteImmutableSamplers = true;
     }


### PR DESCRIPTION
We determine if we should write the ummutable samplers by looking at the
runtime settings.  That is wrong, it should be getting the value from
m_settings.  I don't know the difference or why my earlier tests passed.