### PR TITLE
Clean up cache-{creator,info} unit tests

### DIFF
--- a/tools/cache_creator/unittests/CMakeLists.txt
+++ b/tools/cache_creator/unittests/CMakeLists.txt
@@ -31,8 +31,10 @@
 find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
   COMPONENTS Interpreter)
 
-# Find all the LLVM libraries necessary to use the LLVM components in gtest/gmock.
-set(LLVM_GTEST_LIBS gtest gtest_main)
+# Find the TestingSupport library name that we will link with.
+llvm_map_components_to_libnames(llvm_testing_support_lib TestingSupport)
+
+set(LLVM_GTEST_LIBS gtest gtest_main ${llvm_testing_support_lib})
 if(LLVM_PTHREAD_LIB)
   list(APPEND LLVM_GTEST_LIBS pthread)
 endif()

--- a/tools/cache_creator/unittests/cache_info_tests.cpp
+++ b/tools/cache_creator/unittests/cache_info_tests.cpp
@@ -25,28 +25,20 @@
 #include "cache_info.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Testing/Support/Error.h"
 #include "gmock/gmock.h"
 #include <cassert>
 
-static bool consumeErrorToBool(llvm::Error err) {
-  const bool isError = bool(err);
-  if (isError) {
-    llvm::errs() << err << "\n";
-    llvm::errs().flush();
-  }
-  llvm::consumeError(std::move(err));
-  return isError;
-}
+namespace {
 
-template <typename T> static bool consumeErrorToBool(llvm::Expected<T> &valueOrErr) {
-  return consumeErrorToBool(valueOrErr.takeError());
-}
+using llvm::Failed;
+using llvm::Succeeded;
 
 TEST(CacheInfoTest, EmptyCacheBlob) {
   auto blobPtr = llvm::MemoryBuffer::getMemBuffer(llvm::StringRef{}, "empty", false);
   assert(blobPtr);
   auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
-  EXPECT_TRUE(consumeErrorToBool(blobInfoOrErr));
+  EXPECT_THAT_EXPECTED(blobInfoOrErr, Failed());
 }
 
 TEST(CacheInfoTest, LargeZeroBlob) {
@@ -54,15 +46,15 @@ TEST(CacheInfoTest, LargeZeroBlob) {
   auto blobPtr = llvm::MemoryBuffer::getMemBuffer(llvm::toStringRef(zeros), "zeros", false);
   assert(blobPtr);
   auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
-  EXPECT_FALSE(consumeErrorToBool(blobInfoOrErr));
+  ASSERT_THAT_EXPECTED(blobInfoOrErr, Succeeded());
 
   // This should fail as the self-declared header length is 0.
   auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
-  EXPECT_TRUE(consumeErrorToBool(publicHeaderInfoOrErr));
+  EXPECT_THAT_EXPECTED(publicHeaderInfoOrErr, Failed());
 
   // This should fail as the self-declared header length is 0.
   auto privateHeaderOffsetOrErr = blobInfoOrErr->getPrivateHeaderOffset();
-  EXPECT_TRUE(consumeErrorToBool(privateHeaderOffsetOrErr));
+  EXPECT_THAT_EXPECTED(privateHeaderOffsetOrErr, Failed());
 }
 
 TEST(CacheInfoTest, PublicHeaderOnly) {
@@ -74,7 +66,7 @@ TEST(CacheInfoTest, PublicHeaderOnly) {
 
   // These should fail as the blob is not big enough to contain both a public and a private header.
   auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
-  EXPECT_TRUE(consumeErrorToBool(blobInfoOrErr));
+  EXPECT_THAT_EXPECTED(blobInfoOrErr, Failed());
 }
 
 TEST(CacheInfoTest, PublicHeaderLengthTooLong) {
@@ -87,21 +79,21 @@ TEST(CacheInfoTest, PublicHeaderLengthTooLong) {
 
   // This should succeed because we don't parse the public header at this point and don't know the public header length.
   auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
-  EXPECT_FALSE(consumeErrorToBool(blobInfoOrErr));
+  ASSERT_THAT_EXPECTED(blobInfoOrErr, Succeeded());
 
   // This should succeed as the public header can be fully parsed.
   auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
-  EXPECT_FALSE(consumeErrorToBool(publicHeaderInfoOrErr));
+  ASSERT_THAT_EXPECTED(publicHeaderInfoOrErr, Succeeded());
   EXPECT_EQ(publicHeaderInfoOrErr->publicHeader, publicHeader);
-  EXPECT_EQ(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob, 1);
+  EXPECT_EQ(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob, 1u);
 
   // This should fail as the self-declared header length is too long to fit the private header.
   auto privateHeaderOffsetOrErr = blobInfoOrErr->getPrivateHeaderOffset();
-  EXPECT_TRUE(consumeErrorToBool(privateHeaderOffsetOrErr));
+  EXPECT_THAT_EXPECTED(privateHeaderOffsetOrErr, Failed());
 
   // This should fail as the self-declared header length is too long to fit the private header.
   auto privateHeaderInfoOrErr = blobInfoOrErr->readBinaryCachePrivateHeaderInfo();
-  EXPECT_TRUE(consumeErrorToBool(privateHeaderInfoOrErr));
+  EXPECT_THAT_EXPECTED(privateHeaderInfoOrErr, Failed());
 }
 
 TEST(CacheInfoTest, ValidBlobNoEntries) {
@@ -114,35 +106,35 @@ TEST(CacheInfoTest, ValidBlobNoEntries) {
   assert(blobPtr);
 
   auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
-  EXPECT_FALSE(consumeErrorToBool(blobInfoOrErr));
+  ASSERT_THAT_EXPECTED(blobInfoOrErr, Succeeded());
 
   // These should succeed as both headers can be fully parsed.
   auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
-  EXPECT_FALSE(consumeErrorToBool(publicHeaderInfoOrErr));
+  ASSERT_THAT_EXPECTED(publicHeaderInfoOrErr, Succeeded());
   EXPECT_EQ(publicHeaderInfoOrErr->publicHeader, publicHeader);
-  EXPECT_EQ(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob, 0);
+  EXPECT_EQ(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob, 0u);
 
   auto privateHeaderOffsetOrErr = blobInfoOrErr->getPrivateHeaderOffset();
-  EXPECT_FALSE(consumeErrorToBool(privateHeaderOffsetOrErr));
+  ASSERT_THAT_EXPECTED(privateHeaderOffsetOrErr, Succeeded());
   EXPECT_EQ(*privateHeaderOffsetOrErr, vk::VkPipelineCacheHeaderDataSize);
 
   auto privateHeaderInfoOrErr = blobInfoOrErr->readBinaryCachePrivateHeaderInfo();
-  EXPECT_FALSE(consumeErrorToBool(privateHeaderInfoOrErr));
+  ASSERT_THAT_EXPECTED(privateHeaderInfoOrErr, Succeeded());
   EXPECT_EQ(privateHeaderInfoOrErr->privateHeader, privateHeader);
-  EXPECT_EQ(privateHeaderInfoOrErr->contentBlobSize, 0);
+  EXPECT_EQ(privateHeaderInfoOrErr->contentBlobSize, 0u);
 
   auto contentOffsetOrErr = blobInfoOrErr->getCacheContentOffset();
-  EXPECT_FALSE(consumeErrorToBool(contentOffsetOrErr));
+  ASSERT_THAT_EXPECTED(contentOffsetOrErr, Succeeded());
   EXPECT_EQ(*contentOffsetOrErr, buffer.size());
 
   // This should succeed as it is valid to have an empty cache content, i.e., zero entries.
   llvm::SmallVector<cc::BinaryCacheEntryInfo, 0> entries;
   auto err = blobInfoOrErr->readBinaryCacheEntriesInfo(entries);
-  EXPECT_FALSE(consumeErrorToBool(std::move(err)));
+  EXPECT_THAT_ERROR(std::move(err), Succeeded());
   EXPECT_TRUE(entries.empty());
 }
 
-static cc::MD5DigestStr calculateMD5Sum(llvm::ArrayRef<uint8_t> data) {
+cc::MD5DigestStr calculateMD5Sum(llvm::ArrayRef<uint8_t> data) {
   llvm::MD5 md5;
   md5.update(data);
   llvm::MD5::MD5Result result = {};
@@ -176,28 +168,30 @@ TEST(CacheInfoTest, ValidBlobOneEntry) {
   assert(blobPtr);
 
   auto blobInfoOrErr = cc::CacheBlobInfo::create(*blobPtr);
-  EXPECT_FALSE(consumeErrorToBool(blobInfoOrErr));
+  ASSERT_THAT_EXPECTED(blobInfoOrErr, Succeeded());
 
   // These should all succeed as both headers can be fully parsed and there's one valid entry.
   auto publicHeaderInfoOrErr = blobInfoOrErr->readPublicVkHeaderInfo();
-  EXPECT_FALSE(consumeErrorToBool(publicHeaderInfoOrErr));
+  ASSERT_THAT_EXPECTED(publicHeaderInfoOrErr, Succeeded());
   EXPECT_EQ(publicHeaderInfoOrErr->publicHeader, publicHeader);
   EXPECT_EQ(publicHeaderInfoOrErr->trailingSpaceBeforePrivateBlob, trailingSpace);
 
   auto privateHeaderInfoOrErr = blobInfoOrErr->readBinaryCachePrivateHeaderInfo();
-  EXPECT_FALSE(consumeErrorToBool(privateHeaderInfoOrErr));
+  ASSERT_THAT_EXPECTED(privateHeaderInfoOrErr, Succeeded());
   EXPECT_EQ(privateHeaderInfoOrErr->privateHeader, privateHeader);
   EXPECT_EQ(privateHeaderInfoOrErr->contentBlobSize, sizeof(vk::BinaryCacheEntry) + entrySize);
 
   llvm::SmallVector<cc::BinaryCacheEntryInfo, 1> entries;
   auto err = blobInfoOrErr->readBinaryCacheEntriesInfo(entries);
-  EXPECT_FALSE(consumeErrorToBool(std::move(err)));
-  EXPECT_EQ(entries.size(), 1);
+  ASSERT_THAT_ERROR(std::move(err), Succeeded());
+  EXPECT_EQ(entries.size(), 1u);
 
   cc::BinaryCacheEntryInfo &entry = entries.front();
   EXPECT_EQ(entry.entryHeader, entryHeader);
-  EXPECT_EQ(entry.idx, 0);
+  EXPECT_EQ(entry.idx, 0u);
   EXPECT_EQ(entry.entryBlob.data(), entryBlob.data());
   EXPECT_EQ(entry.entryBlob.size(), entryBlob.size());
   EXPECT_EQ(entry.entryMD5Sum, calculateMD5Sum(entryBlob));
 }
+
+} // namespace


### PR DESCRIPTION
Now that we switched to LLVM's copy of gtest, use the LLVM testing
support library to test for expected values and errors.

Also:
  - Turn some unrecoverable `EXPECTED` failures into `ASSERT`ions.
  - Make integer constants unsigned to avoid signed/unsigned comparison
    warnings.
  - Surround tests with annonymous namespace.