### PR TITLE
[CI] Reflect changes made in LLPC's nightly configuration

### DIFF
--- a/.github/workflows/check-xgl-docker.yml
+++ b/.github/workflows/check-xgl-docker.yml
@@ -17,8 +17,8 @@ jobs:
         host-os:             ["ubuntu-20.04"]
         base-image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
         config:              [Release]
-        feature-set:         ["+gcc", "+clang",
-                              "+gcc+assertions", "+clang+assertions"]
+        feature-set:         ["+gcc", "+gcc+assertions",
+                              "+clang"]
     steps:
       - name: Checkout XGL
         run: |


### PR DESCRIPTION
The `+clang+assertions` configuration has been removed in https://github.com/GPUOpen-Drivers/llpc/pull/1561.