### PR TITLE
Avoid unaligned memory accesses in PBC deserialization

### DIFF
--- a/tools/cache_creator/cache_info.h
+++ b/tools/cache_creator/cache_info.h
@@ -79,7 +79,9 @@ using MD5DigestStr = llvm::SmallString<32>;
 // Represents printable information about a Pipeline Binary Cache entry, its location within the cache blob, and
 // calculated MD5 sum of the entry content.
 struct BinaryCacheEntryInfo {
-  const vk::BinaryCacheEntry *entryHeader;
+  // We do not store the header as `vk::BinaryCacheEntry *` because the address may not be properly aligned.
+  const uint8_t *entryHeader;
+  vk::BinaryCacheEntry entryHeaderData;
   size_t idx;
   llvm::ArrayRef<uint8_t> entryBlob;
   MD5DigestStr entryMD5Sum;


### PR DESCRIPTION
The pipeline binary cache (PBC) data format is as follows:
```
| Public Header | Private Header (20B) | Entry (24B) | Blob (n) | Entry (24B) | ...
```

Binary cache entry headers (`Entry` above) require the alignment of 8 bytes,
which is not guaranteed with this data format. Therefore we cannot use
`reinterpret_cast` to read cache entry headers when reading PBC blobs.

This bug was found with the undefined behavior sanitizer. Although we have not
seen this being a problem in real-world applications, we would like to
get this fixed so that we run the code under UBSan and find other issues
in the future.

Fixes: https://github.com/GPUOpen-Drivers/xgl/issues/143.