### PR TITLE
Disable LLPC optimizations when VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT is set

### DIFF
--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -2370,6 +2370,8 @@ void PipelineCompiler::ApplyPipelineOptions(
         pOptions->includeIr = true;
     }
 
+    pOptions->optimizationLevel = ((flags & VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT) != 0 ? 0 : 2);
+
     if (pDevice->IsExtensionEnabled(DeviceExtensions::EXT_SCALAR_BLOCK_LAYOUT) ||
         pDevice->GetEnabledFeatures().scalarBlockLayout)
     {

--- a/icd/make/importdefs
+++ b/icd/make/importdefs
@@ -36,7 +36,7 @@ ICD_GPUOPEN_CLIENT_MINOR_VERSION = 0
 
 # This will become the value of LLPC_CLIENT_INTERFACE_MAJOR_VERSION if ICD_BUILD_LLPC=1.  It describes the version of the
 # interface version of LLPC that the ICD supports.
-ICD_LLPC_CLIENT_MAJOR_VERSION = 52
+ICD_LLPC_CLIENT_MAJOR_VERSION = 53
 
 # When ICD_LLPC_CLIENT_MAJOR_VERSION >= 39, Set ENABLE_VKGC to 1 to use Vkgc namespace instead of Llpc namespace in ICD
 ENABLE_VKGC=1


### PR DESCRIPTION
This will allow the VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT bit to
have an effect for LLPC.
