### PR TITLE
Fix references to gtest and gmock after llvm update

### DIFF
--- a/tools/cache_creator/unittests/CMakeLists.txt
+++ b/tools/cache_creator/unittests/CMakeLists.txt
@@ -34,7 +34,8 @@ find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
 # Find the TestingSupport library name that we will link with.
 llvm_map_components_to_libnames(llvm_testing_support_lib TestingSupport)
 
-set(LLVM_GTEST_LIBS gtest gtest_main ${llvm_testing_support_lib})
+# Use the gtest support provided by llvm
+set(LLVM_GTEST_LIBS llvm_gtest llvm_gtest_main ${llvm_testing_support_lib})
 if(LLVM_PTHREAD_LIB)
   list(APPEND LLVM_GTEST_LIBS pthread)
 endif()


### PR DESCRIPTION
gtest and gmock have been renamed llvm_gtest and llvm_gmock in the internal llvm
version, to avoid clashes with third-party installs.

Update the cache_creator to take this into account.