### PR TITLE
Handle VK_NULL_HANDLE attachments in VkRenderingFragmentShadingRateAttachmentInfoKHR

### DIFF
--- a/icd/api/vk_cmdbuffer.cpp
+++ b/icd/api/vk_cmdbuffer.cpp
@@ -7509,7 +7509,8 @@ void CmdBuffer::BindTargets(
 
         PalCmdBuffer(deviceIdx)->CmdBindTargets(params);
 
-        if (pRenderingFragmentShadingRateAttachmentInfoKHR != nullptr)
+        if ((pRenderingFragmentShadingRateAttachmentInfoKHR != nullptr) &&
+            (pRenderingFragmentShadingRateAttachmentInfoKHR->imageView != VK_NULL_HANDLE))
         {
             // Get the image view from the attachment info
             const ImageView* const pImageView =


### PR DESCRIPTION
Fixes the draw_instanced test in the vkd3d-proton test suite.