### PR TITLE
Revert "Disable LLPC optimizations when VK_PIPELINE_CREATE_DISABLE_OP…

### DIFF
--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -2370,8 +2370,6 @@ void PipelineCompiler::ApplyPipelineOptions(
         pOptions->includeIr = true;
     }
 
-    pOptions->optimizationLevel = ((flags & VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT) != 0 ? 0 : 2);
-
     if (pDevice->IsExtensionEnabled(DeviceExtensions::EXT_SCALAR_BLOCK_LAYOUT) ||
         pDevice->GetEnabledFeatures().scalarBlockLayout)
     {

--- a/icd/make/importdefs
+++ b/icd/make/importdefs
@@ -36,7 +36,7 @@ ICD_GPUOPEN_CLIENT_MINOR_VERSION = 0
 
 # This will become the value of LLPC_CLIENT_INTERFACE_MAJOR_VERSION if ICD_BUILD_LLPC=1.  It describes the version of the
 # interface version of LLPC that the ICD supports.
-ICD_LLPC_CLIENT_MAJOR_VERSION = 53
+ICD_LLPC_CLIENT_MAJOR_VERSION = 52
 
 # When ICD_LLPC_CLIENT_MAJOR_VERSION >= 39, Set ENABLE_VKGC to 1 to use Vkgc namespace instead of Llpc namespace in ICD
 ENABLE_VKGC=1


### PR DESCRIPTION
…TIMIZATION_BIT is set"

This change cause one game crash, will revert it before it is fixed.

This reverts commit 46e826da04e0d83e2e9d03a756b7f801e0982525.