### PR TITLE
Do not use spvgen.so in cache-creator tests

### DIFF
--- a/tools/cache_creator/test/BasicCacheCreation.spvasm
+++ b/tools/cache_creator/test/BasicCacheCreation.spvasm
@@ -5,13 +5,13 @@
 ; RUN: split-file %s %t
 
 ; Compile the vertex shader into a relocatable ELF. Save the compilation output to a log so that other test can refer to it.
-; RUN: amdllpc %t/vert.spvasm %gfxip %spvgen %reloc -v -o %t.vert.elf > %t.vert.amdllpc.log 2>&1 \
+; RUN: amdllpc %t/vert.spvasm %gfxip %reloc -v -o %t.vert.elf > %t.vert.amdllpc.log 2>&1 \
 ; RUN:   && cat %t.vert.amdllpc.log | FileCheck --check-prefix=LLPC-VERT %s
 ; LLPC-VERT-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; LLPC-VERT-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====
 
 ; Compile the fragment shader into a relocatable ELF. Save the compilation output to a log so that other test can refer to it.
-; RUN: amdllpc %t/frag.spvasm %gfxip %spvgen %reloc -v -o %t.frag.elf > %t.frag.amdllpc.log 2>&1 \
+; RUN: amdllpc %t/frag.spvasm %gfxip %reloc -v -o %t.frag.elf > %t.frag.amdllpc.log 2>&1 \
 ; RUN:   && cat %t.frag.amdllpc.log | FileCheck --check-prefix=LLPC-FRAG %s
 ; LLPC-FRAG-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; LLPC-FRAG-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====

--- a/tools/cache_creator/test/CMakeLists.txt
+++ b/tools/cache_creator/test/CMakeLists.txt
@@ -49,5 +49,5 @@ configure_lit_site_cfg(
 # You can execute test by building the `check-cache-creator` target, e.g., `ninja check-cache-creator`.
 add_lit_testsuite(check-cache-creator "Running the XGL cache creator regression tests"
     ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS cache-creator cache-info amdllpc spvgen FileCheck count not split-file llvm-objdump llvm-readelf
+    DEPENDS cache-creator cache-info amdllpc FileCheck count not split-file llvm-objdump llvm-readelf
 )

--- a/tools/cache_creator/test/NonRelocatableShader.pipe
+++ b/tools/cache_creator/test/NonRelocatableShader.pipe
@@ -1,7 +1,7 @@
 ; Check that cache-creator handles non-relocatable ELFs (i.e., in full pipeline compilation).
 
 ; Compile the full pipeline to a non-relocatable ELF.
-; RUN: amdllpc %spvgen -v %gfxip %s -o %t.elf | FileCheck -check-prefix=CHECK-LLPC %s
+; RUN: amdllpc -v %gfxip %s -o %t.elf | FileCheck -check-prefix=CHECK-LLPC %s
 ; CHECK-LLPC: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; CHECK-LLPC: AMDLLPC SUCCESS
 

--- a/tools/cache_creator/test/RunLitCommands.spvasm
+++ b/tools/cache_creator/test/RunLitCommands.spvasm
@@ -1,5 +1,5 @@
 ; Check if lit is configured properly and that all basic tools run.
-; RUN: amdllpc %s %gfxip %spvgen %reloc -v -o %t.elf | FileCheck --check-prefix=CHECK-LLPC %s
+; RUN: amdllpc %s %gfxip %reloc -v -o %t.elf | FileCheck --check-prefix=CHECK-LLPC %s
 ; CHECK-LLPC: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; CHECK-LLPC: AMDLLPC SUCCESS
 

--- a/tools/cache_creator/test/lit.cfg.py
+++ b/tools/cache_creator/test/lit.cfg.py
@@ -53,7 +53,6 @@ llvm_config.use_default_substitutions()
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%gfxip', '-gfxip=' + config.gfxip))
-config.substitutions.append(('%spvgen', '-spvgen-dir=' + config.spvgen_dir))
 config.substitutions.append(('%reloc', '-unlinked -enable-relocatable-shader-elf'))
 
 tool_dirs = [config.cache_creator_tools_dir, config.amdllpc_dir, config.llvm_tools_dir]

--- a/tools/cache_creator/test/lit.site.cfg.py.in
+++ b/tools/cache_creator/test/lit.site.cfg.py.in
@@ -13,7 +13,6 @@ config.llvm_assertions = "@LLVM_ENABLE_ASSERTIONS@"
 config.cache_creator_tools_dir = "@CACHE_CREATOR_TOOLS_BINARY_DIR@"
 config.amdllpc_dir = "@CACHE_CREATOR_AMDLLPC_DIR@"
 config.gfxip = "@CACHE_CREATOR_DEFAULT_GFXIP@"
-config.spvgen_dir = "@CACHE_CREATOR_SPVGEN_DIR@"
 config.test_run_dir = "@CACHE_CREATOR_TEST_BINARY_DIR@"
 
 # Support substitution of the tools_dir with user parameters. This is


### PR DESCRIPTION
amdllpc does not use spvgen.so anymore.
This fixes test failures.