### PR TITLE
Reinstate: Disable LLPC optimizations when VK_PIPELINE_CREATE_DISABLE…

### DIFF
--- a/icd/api/pipeline_compiler.cpp
+++ b/icd/api/pipeline_compiler.cpp
@@ -2632,6 +2632,8 @@ void PipelineCompiler::ApplyPipelineOptions(
         pOptions->includeIr = true;
     }
 
+    pOptions->optimizationLevel = ((flags & VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT) != 0 ? 0 : 2);
+
     if (pDevice->IsExtensionEnabled(DeviceExtensions::EXT_SCALAR_BLOCK_LAYOUT) ||
         pDevice->GetEnabledFeatures().scalarBlockLayout)
     {

--- a/icd/make/importdefs
+++ b/icd/make/importdefs
@@ -36,7 +36,7 @@ ICD_GPUOPEN_CLIENT_MINOR_VERSION = 0
 
 # This will become the value of LLPC_CLIENT_INTERFACE_MAJOR_VERSION if ICD_BUILD_LLPC=1.  It describes the version of the
 # interface version of LLPC that the ICD supports.
-ICD_LLPC_CLIENT_MAJOR_VERSION = 52
+ICD_LLPC_CLIENT_MAJOR_VERSION = 53
 
 # When ICD_LLPC_CLIENT_MAJOR_VERSION >= 39, Set ENABLE_VKGC to 1 to use Vkgc namespace instead of Llpc namespace in ICD
 ENABLE_VKGC=1

--- a/tools/cache_creator/docker/check_xgl.Dockerfile
+++ b/tools/cache_creator/docker/check_xgl.Dockerfile
@@ -36,6 +36,7 @@ RUN cat /vulkandriver/build_info.txt \
 # Build XGL targets.
 WORKDIR /vulkandriver/builds/ci-build
 RUN source /vulkandriver/env.sh \
+    && cmake . \
     && cmake --build . \
     && cmake --build . --target amdvlk64.so cache-creator
 


### PR DESCRIPTION
…_OPTIMIZATION_BIT is set

This will allow the VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT bit to
have an effect for LLPC.

Re-submitting this change after it was reverted