### PR TITLE
Cache-creator run cmake to update to latest version defines

### DIFF
--- a/tools/cache_creator/docker/check_xgl.Dockerfile
+++ b/tools/cache_creator/docker/check_xgl.Dockerfile
@@ -36,6 +36,7 @@ RUN cat /vulkandriver/build_info.txt \
 # Build XGL targets.
 WORKDIR /vulkandriver/builds/ci-build
 RUN source /vulkandriver/env.sh \
+    && cmake . \
     && cmake --build . \
     && cmake --build . --target amdvlk64.so cache-creator
 


### PR DESCRIPTION
Sometimes we need to run cmake to ensure that all version number defines are
properly up to date.