### PR TITLE
Remove deprecated cmake flag `XGL_BUILD_LIT`

### DIFF
--- a/cmake/XglOptions.cmake
+++ b/cmake/XglOptions.cmake
@@ -49,9 +49,6 @@ macro(xgl_options)
 
     option(XGL_BUILD_TESTS "Build all tests?" OFF)
 
-    # Deprecated, use XGL_BUILD_TESTS instead.
-    option(XGL_BUILD_LIT "Build with Lit test?" OFF)
-
     option(XGL_BUILD_CACHE_CREATOR "Build cache-creator tools?" OFF)
 
 #if VKI_GPU_DECOMPRESS

--- a/cmake/XglOverrides.cmake
+++ b/cmake/XglOverrides.cmake
@@ -192,11 +192,6 @@ macro(xgl_overrides_vkgc)
 
     set(LLPC_BUILD_TESTS ${XGL_BUILD_TESTS} CACHE BOOL "${PROJECT_NAME} override." FORCE)
 
-    set(LLPC_BUILD_LIT ${XGL_BUILD_LIT} CACHE BOOL "${PROJECT_NAME} override." FORCE)
-
-    if(XGL_BUILD_LIT)
-        message(DEPRECATION "XGL_BUILD_LIT is deprecated, use XGL_BUILD_TESTS instead")
-    endif()
     set(LLPC_BUILD_NAVI12 ${XGL_BUILD_NAVI12} CACHE BOOL "${PROJECT_NAME} override." FORCE)
 
     set(LLPC_BUILD_NAVI22 ${XGL_BUILD_NAVI22} CACHE BOOL "${PROJECT_NAME} override." FORCE)

--- a/tools/cache_creator/CMakeLists.txt
+++ b/tools/cache_creator/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(cache-info PRIVATE cache_creator_lib)
 # Build cache creator tools whenever we build XGL.
 add_dependencies(xgl cache-creator cache-info)
 
-if(XGL_BUILD_TESTS OR XGL_BUILD_LIT)
+if(XGL_BUILD_TESTS)
     message(STATUS "Building cache creator tests")
     set(CACHE_CREATOR_TOOLS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
     add_subdirectory(test "${CMAKE_CURRENT_BINARY_DIR}/test/cache-creator/lit")


### PR DESCRIPTION
This flag was deprecated 9 months ago in favor of `XGL_BUILD_TESTS`.

Issue: https://github.com/GPUOpen-Drivers/llpc/issues/1826