### PR TITLE
Update BasicCacheCreation test

### DIFF
--- a/tools/cache_creator/test/BasicCacheCreation.spvasm
+++ b/tools/cache_creator/test/BasicCacheCreation.spvasm
@@ -6,15 +6,15 @@
 
 ; Compile the vertex shader into a relocatable ELF. Save the compilation output to a log so that other test can refer to it.
 ; RUN: amdllpc %t/vert.spvasm %gfxip %reloc -v -o %t.vert.elf > %t.vert.amdllpc.log 2>&1 \
-; RUN:   && cat %t.vert.amdllpc.log | FileCheck --check-prefix=LLPC-VERT %s
-; LLPC-VERT-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; LLPC-VERT-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====
+; RUN:   && cat %t.vert.amdllpc.log | FileCheck --match-full-lines --check-prefix=LLPC-VERT %s
+; LLPC-VERT-LABEL: // LLPC SPIRV-to-LLVM translation results
+; LLPC-VERT-LABEL: =====  AMDLLPC SUCCESS  =====
 
 ; Compile the fragment shader into a relocatable ELF. Save the compilation output to a log so that other test can refer to it.
 ; RUN: amdllpc %t/frag.spvasm %gfxip %reloc -v -o %t.frag.elf > %t.frag.amdllpc.log 2>&1 \
-; RUN:   && cat %t.frag.amdllpc.log | FileCheck --check-prefix=LLPC-FRAG %s
-; LLPC-FRAG-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; LLPC-FRAG-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====
+; RUN:   && cat %t.frag.amdllpc.log | FileCheck --match-full-lines --check-prefix=LLPC-FRAG %s
+; LLPC-FRAG-LABEL: // LLPC SPIRV-to-LLVM translation results
+; LLPC-FRAG-LABEL: =====  AMDLLPC SUCCESS  =====
 
 
 ; Test 1: Create a cache file with one input. Check that the cache contents have the right format
@@ -22,44 +22,45 @@
 ; RUN: cache-creator %t.vert.elf --uuid=00000001-0020-0300-4000-50000000000f --device-id=0x6080 \
 ; RUN:               -o %t.vert.bin --verbose > %t.vert.cc.log 2>&1 \
 ; RUN:   && cache-info %t.vert.bin > %t.vert.ci.log 2>&1 \
-; RUN:   && cat %t.vert.cc.log %t.vert.ci.log %t.vert.amdllpc.log | FileCheck --check-prefix=CC-VERT %s
+; RUN:   && cat %t.vert.cc.log %t.vert.ci.log %t.vert.amdllpc.log \
+; RUN:   | FileCheck --match-full-lines --check-prefix=CC-VERT %s
 ; Part 1a: Check cache-creator output.
-; CC-VERT:       {{^Num}} inputs: 1, anticipated cache size: [[#vert_cache_size:]]{{$}}
-; CC-VERT-NEXT:  {{^Read:}} {{.*}}.vert.elf{{$}}
-; CC-VERT:       {{^Num}} entries written: 1, actual cache size: [[#vert_cache_size]] B{{$}}
-; CC-VERT:       {{^Cache}} successfully written to: [[cache_file_path:.*\.vert\.bin]]{{$}}
+; CC-VERT:       Num inputs: 1, anticipated cache size: [[#vert_cache_size:]]
+; CC-VERT-NEXT:  Read: {{.*}}.vert.elf
+; CC-VERT:       Num entries written: 1, actual cache size: [[#vert_cache_size]] B
+; CC-VERT:       Cache successfully written to: [[cache_file_path:.*\.vert\.bin]]
 ;
 ; Part 1b: Check cache-info output.
-; CC-VERT:       {{^Read:}} [[cache_file_path]], [[#vert_cache_size]] B{{$}}
+; CC-VERT:       Read: [[cache_file_path]], [[#vert_cache_size]] B
 ;
-; CC-VERT-LABEL: {{^===}} Vulkan Pipeline Cache Header
-; CC-VERT-NEXT:  {{^header length:}} [[#vk_header_len:32]]{{$}}
-; CC-VERT-NEXT:  {{^header version:}} 1{{$}}
-; CC-VERT-NEXT:  {{^vendor ID:}} 0x1002{{$}}
-; CC-VERT-NEXT:  {{^device ID:}} 0x6080{{$}}
-; CC-VERT-NEXT:  {{^pipeline cache UUID:}} 00000001-0020-0300-4000-50000000000f{{$}}
-; CC-VERT-NEXT:  {{^trailing space:}} 0{{$}}
+; CC-VERT-LABEL: === Vulkan Pipeline Cache Header ===
+; CC-VERT-NEXT:  header length: [[#vk_header_len:32]]
+; CC-VERT-NEXT:  header version: 1
+; CC-VERT-NEXT:  vendor ID: 0x1002
+; CC-VERT-NEXT:  device ID: 0x6080
+; CC-VERT-NEXT:  pipeline cache UUID: 00000001-0020-0300-4000-50000000000f
+; CC-VERT-NEXT:  trailing space: 0
 ;
-; CC-VERT-LABEL: {{^===}} Pipeline Binary Cache Private Header
-; CC-VERT-NEXT:  {{^header length:}} [[#pbc_header_len:20]]{{$}}
-; CC-VERT-NEXT:  {{^hash ID:}} {{([0-9a-f]{8} ?){5}$}}
-; CC-VERT-NEXT:  {{^content size:}} [[#vert_cache_size - vk_header_len - pbc_header_len]]{{$}}
+; CC-VERT-LABEL: === Pipeline Binary Cache Private Header ===
+; CC-VERT-NEXT:  header length: [[#pbc_header_len:20]]
+; CC-VERT-NEXT:  hash ID: {{([0-9a-f]{8} ?){5}$}}
+; CC-VERT-NEXT:  content size: [[#vert_cache_size - vk_header_len - pbc_header_len]]
 ;
-; CC-VERT-LABEL: {{^===}} Cache Content Info
-; CC-VERT-NEXT:  {{^total num entries:}} 1{{$}}
-; CC-VERT-NEXT:  {{^entry header length:}} [[#entry_header_len:24]]{{$}}
-; CC-VERT-LABEL: {{^}} *** Entry 0 ***
-; CC-VERT-NEXT:  {{^}} hash ID: [[vert_cache_hash:(0x[0-9a-f]{16} ?){2}]]{{$}}
-; CC-VERT-NEXT:  {{^}} data size: [[#vert_cache_size - vk_header_len - pbc_header_len - entry_header_len]]{{$}}
-; CC-VERT-NEXT:  {{^}} calculated MD5 sum: {{[0-9a-f]{32}$}}
-; CC-VERT-NEXT:  {{^}} matched source file: <none>{{$}}
+; CC-VERT-LABEL: === Cache Content Info ===
+; CC-VERT-NEXT:  total num entries: 1
+; CC-VERT-NEXT:  entry header length: [[#entry_header_len:24]]
+; CC-VERT-LABEL:  *** Entry 0 ***
+; CC-VERT-NEXT:   hash ID: [[vert_cache_hash:(0x[0-9a-f]{16} ?){2}]]
+; CC-VERT-NEXT:   data size: [[#vert_cache_size - vk_header_len - pbc_header_len - entry_header_len]]
+; CC-VERT-NEXT:   calculated MD5 sum: {{[0-9a-f]{32}$}}
+; CC-VERT-NEXT:   matched source file: <none>
 ;
-; CC-VERT-LABEL: {{^===}} Cache Info analysis finished
+; CC-VERT-LABEL: === Cache Info analysis finished ===
 ;
 ; Part 1c: Check amdllpc output to see that the entry hash ID from 1b matches the compiler vertex cache hash.
-; CC-VERT:       SPIR-V disassembly for {{.*}}vert.spvasm{{$}}
-; CC-VERT-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
-; CC-VERT:       {{^Finalized}} hash for vertex stage cache lookup: [[vert_cache_hash]]{{$}}
+; CC-VERT:       SPIR-V disassembly for {{.*}}vert.spvasm:
+; CC-VERT-LABEL: // LLPC calculated hash results (graphics pipeline)
+; CC-VERT:       Finalized hash for vertex stage cache lookup: [[vert_cache_hash]]
 
 
 ; Test 2: Create a cache file with two inputs. Check that both ELFs are present in the cache file.
@@ -67,49 +68,49 @@
 ; RUN:               -o %t.vert-frag.bin --verbose > %t.vert-frag.cc.log 2>&1 \
 ; RUN:   && cache-info %t.vert-frag.bin --elf-source-dir=%T > %t.vert-frag.ci.log 2>&1 \
 ; RUN:   && cat %t.vert-frag.cc.log %t.vert-frag.ci.log %t.vert.amdllpc.log %t.frag.amdllpc.log \
-; RUN:   | FileCheck --check-prefix=CC-TWO %s
+; RUN:   | FileCheck --match-full-lines --check-prefix=CC-TWO %s
 ; Part 2a: Check cache-creator output.
-; CC-TWO:       {{^Num}} inputs: 2, anticipated cache size: [[#two_cache_size:]]{{$}}
-; CC-TWO-NEXT:  {{^Read:}} [[vert_elf_path:.*\.vert\.elf]]{{$}}
-; CC-TWO:       {{^Read:}} [[frag_elf_path:.*\.frag\.elf]]{{$}}
-; CC-TWO:       {{^Num}} entries written: 2, actual cache size: [[#two_cache_size]] B{{$}}
-; CC-TWO:       {{^Cache}} successfully written to: [[cache_file_path:.*\.vert-frag\.bin]]{{$}}
+; CC-TWO:       Num inputs: 2, anticipated cache size: [[#two_cache_size:]]
+; CC-TWO-NEXT:  Read: [[vert_elf_path:.*\.vert\.elf]]
+; CC-TWO:       Read: [[frag_elf_path:.*\.frag\.elf]]
+; CC-TWO:       Num entries written: 2, actual cache size: [[#two_cache_size]] B
+; CC-TWO:       Cache successfully written to: [[cache_file_path:.*\.vert-frag\.bin]]
 ;
 ; Part 2b: Check cache-info output.
-; CC-TWO:       {{^Read:}} {{.*}}.vert-frag.bin, [[#two_cache_size]] B{{$}}
+; CC-TWO:       Read: {{.*}}.vert-frag.bin, [[#two_cache_size]] B
 ;
-; CC-TWO-LABEL: {{^===}} Vulkan Pipeline Cache Header
-; CC-TWO-NEXT:  {{^header length:}} [[#vk_header_len:32]]{{$}}
-; CC-TWO:       {{^trailing space:}} 0{{$}}
+; CC-TWO-LABEL: === Vulkan Pipeline Cache Header ===
+; CC-TWO-NEXT:  header length: [[#vk_header_len:32]]
+; CC-TWO:       trailing space: 0
 ;
-; CC-TWO-LABEL: {{^===}} Pipeline Binary Cache Private Header
-; CC-TWO-NEXT:  {{^header length:}} [[#pbc_header_len:20]]{{$}}
-; CC-TWO:       {{^content size:}} [[#two_cache_size - vk_header_len - pbc_header_len]]{{$}}
+; CC-TWO-LABEL: === Pipeline Binary Cache Private Header ===
+; CC-TWO-NEXT:  header length: [[#pbc_header_len:20]]
+; CC-TWO:       content size: [[#two_cache_size - vk_header_len - pbc_header_len]]
 ;
-; CC-TWO-LABEL: {{^===}} Cache Content Info
-; CC-TWO-NEXT:  {{^total num entries:}} 2{{$}}
-; CC-TWO-NEXT:  {{^entry header length:}} [[#entry_header_len:24]]{{$}}
+; CC-TWO-LABEL: === Cache Content Info ===
+; CC-TWO-NEXT:  total num entries: 2
+; CC-TWO-NEXT:  entry header length: [[#entry_header_len:24]]
 ;
-; CC-TWO-LABEL: {{^}} *** Entry 0 ***
-; CC-TWO-NEXT:  {{^}} hash ID: [[vert_cache_hash:(0x[0-9a-f]{16} ?){2}]]{{$}}
-; CC-TWO-NEXT:  {{^}} data size: [[#vert_entry_data_size:]]{{$}}
-; CC-TWO-NEXT:  {{^}} calculated MD5 sum: {{[0-9a-f]{32}$}}
-; CC-TWO-NEXT:  {{^}} matched source file: [[vert_elf_path]]{{$}}
+; CC-TWO-LABEL:  *** Entry 0 ***
+; CC-TWO-NEXT:   hash ID: [[vert_cache_hash:(0x[0-9a-f]{16} ?){2}]]
+; CC-TWO-NEXT:   data size: [[#vert_entry_data_size:]]
+; CC-TWO-NEXT:   calculated MD5 sum: {{[0-9a-f]{32}$}}
+; CC-TWO-NEXT:   matched source file: [[vert_elf_path]]
 ;
-; CC-TWO-LABEL: {{^}} *** Entry 1 ***
-; CC-TWO-NEXT:  {{^}} hash ID: [[frag_cache_hash:(0x[0-9a-f]{16} ?){2}]]{{$}}
-; CC-TWO-NEXT:  {{^}} data size: [[#two_cache_size - vk_header_len - pbc_header_len - entry_header_len - vert_entry_data_size - entry_header_len]]{{$}}
-; CC-TWO-NEXT:  {{^}} calculated MD5 sum: {{[0-9a-f]{32}$}}
-; CC-TWO-NEXT:  {{^}} matched source file: [[frag_elf_path]]{{$}}
+; CC-TWO-LABEL:  *** Entry 1 ***
+; CC-TWO-NEXT:   hash ID: [[frag_cache_hash:(0x[0-9a-f]{16} ?){2}]]
+; CC-TWO-NEXT:   data size: [[#two_cache_size - vk_header_len - pbc_header_len - entry_header_len - vert_entry_data_size - entry_header_len]]
+; CC-TWO-NEXT:   calculated MD5 sum: {{[0-9a-f]{32}$}}
+; CC-TWO-NEXT:   matched source file: [[frag_elf_path]]
 ;
 ; Part 2c: Check amdllpc output to see that the entry hash IDs from 2b match the compiler vertex and fragment cache hashes.
-; CC-TWO:       SPIR-V disassembly for {{.*}}vert.spvasm{{$}}
-; CC-TWO-LABEL: {{// LLPC}} calculated hash results (graphics pipeline)
-; CC-TWO:       {{^Finalized}} hash for vertex stage cache lookup: [[vert_cache_hash]]{{$}}
+; CC-TWO:       SPIR-V disassembly for {{.*}}vert.spvasm:
+; CC-TWO-LABEL: // LLPC calculated hash results (graphics pipeline)
+; CC-TWO:       Finalized hash for vertex stage cache lookup: [[vert_cache_hash]]
 ;
-; CC-TWO:       SPIR-V disassembly for {{.*}}frag.spvasm{{$}}
-; CC-TWO-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
-; CC-TWO:       {{^Finalized}} hash for fragment stage cache lookup: [[frag_cache_hash]]{{$}}
+; CC-TWO:       SPIR-V disassembly for {{.*}}frag.spvasm:
+; CC-TWO-LABEL: // LLPC calculated hash results (graphics pipeline)
+; CC-TWO:       Finalized hash for fragment stage cache lookup: [[frag_cache_hash]]
 
 
 ; Test 3: Create a cache file with one input repeated twice.
@@ -117,36 +118,37 @@
 ; RUN: cache-creator %t.vert.elf %t.vert.elf --uuid=00000000-0000-0000-0000-000000000000 --device-id=0x6080 \
 ; RUN:               -o %t.vert-vert.bin --verbose > %t.vert-vert.cc.log 2>&1 \
 ; RUN:   && cache-info %t.vert-vert.bin --elf-source-dir=%T > %t.vert-vert.ci.log 2>&1 \
-; RUN:   && cat %t.vert-vert.cc.log %t.vert-vert.ci.log %t.vert.amdllpc.log | FileCheck --check-prefix=CC-DUP %s
+; RUN:   && cat %t.vert-vert.cc.log %t.vert-vert.ci.log %t.vert.amdllpc.log \
+; RUN:   | FileCheck --match-full-lines --check-prefix=CC-DUP %s
 ; Part 3a: Check cache-creator output.
-; CC-DUP:       {{^Num}} inputs: 2, anticipated cache size: [[#dup_cache_size:]]{{$}}
-; CC-DUP-NEXT:  {{^Read:}} [[vert_elf_path:.*\.vert\.elf]]{{$}}
-; CC-DUP:       {{^Read:}} [[vert_elf_path]]{{$}}
-; CC-DUP:       {{^Num}} entries written: 2, actual cache size: [[#dup_cache_size]] B{{$}}
-; CC-DUP:       {{^Cache}} successfully written to: [[cache_file_path:.*\.vert-vert\.bin]]{{$}}
+; CC-DUP:       Num inputs: 2, anticipated cache size: [[#dup_cache_size:]]
+; CC-DUP-NEXT:  Read: [[vert_elf_path:.*\.vert\.elf]]
+; CC-DUP:       Read: [[vert_elf_path]]
+; CC-DUP:       Num entries written: 2, actual cache size: [[#dup_cache_size]] B
+; CC-DUP:       Cache successfully written to: [[cache_file_path:.*\.vert-vert\.bin]]
 ;
 ; Part 3b: Check cache-info output.
-; CC-DUP:       {{^Read:}} [[cache_file_path]], [[#dup_cache_size]] B{{$}}
+; CC-DUP:       Read: [[cache_file_path]], [[#dup_cache_size]] B
 ;
-; CC-DUP-LABEL: {{^===}} Cache Content Info
-; CC-DUP-NEXT:  {{^total num entries:}} 2{{$}}
+; CC-DUP-LABEL: === Cache Content Info ===
+; CC-DUP-NEXT:  total num entries: 2
 ;
-; CC-DUP-LABEL: {{^}} *** Entry 0 ***
-; CC-DUP-NEXT:  {{^}} hash ID: [[vert_cache_hash:(0x[0-9a-f]{16} ?){2}]]{{$}}
-; CC-DUP-NEXT:  {{^}} data size: [[#vert_entry_data_size:]]{{$}}
-; CC-DUP-NEXT:  {{^}} calculated MD5 sum: [[vert_md5_sum:[0-9a-f]{32}]]{{$}}
-; CC-DUP-NEXT:  {{^}} matched source file: [[vert_elf_path]]{{$}}
+; CC-DUP-LABEL:  *** Entry 0 ***
+; CC-DUP-NEXT:   hash ID: [[vert_cache_hash:(0x[0-9a-f]{16} ?){2}]]
+; CC-DUP-NEXT:   data size: [[#vert_entry_data_size:]]
+; CC-DUP-NEXT:   calculated MD5 sum: [[vert_md5_sum:[0-9a-f]{32}]]
+; CC-DUP-NEXT:   matched source file: [[vert_elf_path]]
 ;
-; CC-DUP-LABEL: {{^}} *** Entry 1 ***
-; CC-DUP-NEXT:  {{^}} hash ID: [[vert_cache_hash]]{{$}}
-; CC-DUP-NEXT:  {{^}} data size: [[#vert_entry_data_size]]{{$}}
-; CC-DUP-NEXT:  {{^}} calculated MD5 sum: [[vert_md5_sum]]{{$}}
-; CC-DUP-NEXT:  {{^}} matched source file: [[vert_elf_path]]{{$}}
+; CC-DUP-LABEL:  *** Entry 1 ***
+; CC-DUP-NEXT:   hash ID: [[vert_cache_hash]]
+; CC-DUP-NEXT:   data size: [[#vert_entry_data_size]]
+; CC-DUP-NEXT:   calculated MD5 sum: [[vert_md5_sum]]
+; CC-DUP-NEXT:   matched source file: [[vert_elf_path]]
 ;
 ; Part 3c: Check amdllpc output to see that the entry hash ID from 2b matches the compiler vertex cache hash.
-; CC-DUP:       SPIR-V disassembly for {{.*}}vert.spvasm{{$}}
-; CC-DUP-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
-; CC-DUP:       {{^Finalized}} hash for vertex stage cache lookup: [[vert_cache_hash]]{{$}}
+; CC-DUP:       SPIR-V disassembly for {{.*}}vert.spvasm:
+; CC-DUP-LABEL: // LLPC calculated hash results (graphics pipeline)
+; CC-DUP:       Finalized hash for vertex stage cache lookup: [[vert_cache_hash]]
 
 
 ;--- vert.spvasm


### PR DESCRIPTION
Update spir-v disassembly matches for https://github.com/GPUOpen-Drivers/llpc/pull/1840.

Simplify check directives by switching to `--match-full-lines`.