### PR TITLE
Fix buffer overflow when the count of display modes exceeds MaxModePe…

### DIFF
--- a/icd/api/include/vk_instance.h
+++ b/icd/api/include/vk_instance.h
@@ -352,7 +352,7 @@ private:
     {
         Pal::IScreen*       pPalScreen;
         uint32_t            modeCount;
-        Pal::ScreenMode*    pModeList[Pal::MaxModePerScreen];
+        Pal::ScreenMode*    pModeList;
     };
 
     uint32_t        m_screenCount;


### PR DESCRIPTION
…rScreen(64)

1. Free pModeList memory when destroying instance
2. Add protection when allocating memory for pModeList fails
3. Avoid using an early return
4. Remove the if condition of ppModeList == nullptr, it doesn't match the new calling conventions
5. Always initialize variables