### PR TITLE
Fix implementation of VK_EXT_depth_clamp_control

### DIFF
--- a/icd/api/graphics_pipeline_common.cpp
+++ b/icd/api/graphics_pipeline_common.cpp
@@ -1026,7 +1026,6 @@ static void CopyPreRasterizationShaderState(
     }
     pInfo->immedInfo.dynamicGraphicsState      = libInfo.immedInfo.dynamicGraphicsState;
     pInfo->immedInfo.viewportParams            = libInfo.immedInfo.viewportParams;
-    pInfo->immedInfo.depthClampOverride        = libInfo.immedInfo.depthClampOverride;
     pInfo->immedInfo.scissorRectParams         = libInfo.immedInfo.scissorRectParams;
     pInfo->immedInfo.rasterizerDiscardEnable   = libInfo.immedInfo.rasterizerDiscardEnable;
 
@@ -1369,15 +1368,17 @@ static void BuildViewportState(
             const auto* pClampControl = pPipelineViewportDepthClampControlCreateInfoEXT;
             if (pClampControl != nullptr)
             {
+                const auto* pClampRange = pClampControl->pDepthClampRange;
                 switch (pClampControl->depthClampMode)
                 {
                 case VK_DEPTH_CLAMP_MODE_VIEWPORT_RANGE_EXT:
                     // set min > max to disable the override
-                    pInfo->immedInfo.depthClampOverride.minDepthClamp = 1.0f;
-                    pInfo->immedInfo.depthClampOverride.maxDepthClamp = 0.0f;
+                    pInfo->immedInfo.viewportParams.depthClampOverride.minDepth = 1.0f;
+                    pInfo->immedInfo.viewportParams.depthClampOverride.maxDepth = 0.0f;
                     break;
                 case VK_DEPTH_CLAMP_MODE_USER_DEFINED_RANGE_EXT:
-                    pInfo->immedInfo.depthClampOverride = *pClampControl->pDepthClampRange;
+                    pInfo->immedInfo.viewportParams.depthClampOverride.minDepth = pClampRange->minDepthClamp;
+                    pInfo->immedInfo.viewportParams.depthClampOverride.maxDepth = pClampRange->maxDepthClamp;
                     break;
                 default:
                     VK_ASSERT(!"Unexpected depthClampMode");
@@ -1387,8 +1388,8 @@ static void BuildViewportState(
             else
             {
                 // set min > max to disable the override
-                pInfo->immedInfo.depthClampOverride.minDepthClamp = 1.0f;
-                pInfo->immedInfo.depthClampOverride.maxDepthClamp = 0.0f;
+                pInfo->immedInfo.viewportParams.depthClampOverride.minDepth = 1.0f;
+                pInfo->immedInfo.viewportParams.depthClampOverride.maxDepth = 0.0f;
             }
         }
 

--- a/icd/api/include/graphics_pipeline_common.h
+++ b/icd/api/include/graphics_pipeline_common.h
@@ -66,8 +66,6 @@ struct GraphicsPipelineObjectImmedInfo
     Pal::PointLineRasterStateParams       pointLineRasterParams;
     Pal::LineStippleStateParams           lineStippleParams;
     Pal::ViewportParams                   viewportParams;
-    // min > max means that the override is not active
-    VkDepthClampRangeEXT                  depthClampOverride;
     Pal::ScissorRectParams                scissorRectParams;
     Pal::StencilRefMaskParams             stencilRefMasks;
     SamplePattern                         samplePattern;

--- a/icd/api/include/vk_cmdbuffer.h
+++ b/icd/api/include/vk_cmdbuffer.h
@@ -325,9 +325,6 @@ struct AllGpuRenderState
         uint32_t fragmentShadingRate;
     } staticTokens;
 
-    // min > max means that the override is not active
-    VkDepthClampRangeEXT depthClampOverride;
-
     // Which Vulkan PipelineBindPoint currently owns the state of each PAL pipeline bind point.  This is
     // relevant because e.g. multiple Vulkan pipeline bind points are implemented as compute pipelines and used through
     // the same PAL pipeline bind point.

--- a/icd/api/vk_cmdbuffer.cpp
+++ b/icd/api/vk_cmdbuffer.cpp
@@ -1747,9 +1747,6 @@ void CmdBuffer::ResetPipelineState()
 
     memset(&m_allGpuState.samplePattern, 0u, sizeof(m_allGpuState.samplePattern));
 
-    m_allGpuState.depthClampOverride.minDepthClamp = 1.0f;
-    m_allGpuState.depthClampOverride.maxDepthClamp = 0.0f;
-
     uint32_t bindIdx = 0;
 
     do
@@ -1799,20 +1796,21 @@ void CmdBuffer::ResetPipelineState()
     {
         PerGpuRenderState* pPerGpuState = PerGpuState(deviceIdx);
 
-        pPerGpuState->pMsaaState                = nullptr;
-        pPerGpuState->pColorBlendState          = nullptr;
-        pPerGpuState->pDepthStencilState        = nullptr;
-        pPerGpuState->scissor.count             = 1;
-        pPerGpuState->scissor.scissors[0]       = {};
-        pPerGpuState->viewport.count            = 1;
-        pPerGpuState->viewport.viewports[0]     = {};
-        pPerGpuState->viewport.horzClipRatio    = FLT_MAX;
-        pPerGpuState->viewport.vertClipRatio    = FLT_MAX;
-        pPerGpuState->viewport.horzDiscardRatio = 1.0f;
-        pPerGpuState->viewport.vertDiscardRatio = 1.0f;
-        pPerGpuState->viewport.depthRange       = Pal::DepthRange::ZeroToOne;
-        pPerGpuState->maxPipelineStackSizes     = {};
-        pPerGpuState->dynamicPipelineStackSize  = 0;
+        pPerGpuState->pMsaaState                  = nullptr;
+        pPerGpuState->pColorBlendState            = nullptr;
+        pPerGpuState->pDepthStencilState          = nullptr;
+        pPerGpuState->scissor.count               = 1;
+        pPerGpuState->scissor.scissors[0]         = {};
+        pPerGpuState->viewport.count              = 1;
+        pPerGpuState->viewport.viewports[0]       = {};
+        pPerGpuState->viewport.horzClipRatio      = FLT_MAX;
+        pPerGpuState->viewport.vertClipRatio      = FLT_MAX;
+        pPerGpuState->viewport.horzDiscardRatio   = 1.0f;
+        pPerGpuState->viewport.vertDiscardRatio   = 1.0f;
+        pPerGpuState->viewport.depthRange         = Pal::DepthRange::ZeroToOne;
+        pPerGpuState->viewport.depthClampOverride = { 1.0f, 0.0f };
+        pPerGpuState->maxPipelineStackSizes       = {};
+        pPerGpuState->dynamicPipelineStackSize    = 0;
 
         deviceIdx++;
     }
@@ -10198,19 +10196,31 @@ void CmdBuffer::CmdSetDepthClampRangeEXT(
     VkDepthClampModeEXT                         depthClampMode,
     const VkDepthClampRangeEXT*                 pDepthClampRange)
 {
-    switch (depthClampMode)
+    VK_ASSERT(m_cbBeginDeviceMask == m_pDevice->GetPalDeviceMask());
+    utils::IterateMask deviceGroup(m_cbBeginDeviceMask);
+    do
     {
-    case VK_DEPTH_CLAMP_MODE_VIEWPORT_RANGE_EXT:
-        m_allGpuState.depthClampOverride.minDepthClamp = 1.0f;
-        m_allGpuState.depthClampOverride.maxDepthClamp = 0.0f;
-        break;
-    case VK_DEPTH_CLAMP_MODE_USER_DEFINED_RANGE_EXT:
-        m_allGpuState.depthClampOverride = *pDepthClampRange;
-        break;
-    default:
-        VK_ASSERT(!"Unexpected depthClampMode");
-        break;
+        const uint32_t deviceIdx = deviceGroup.Index();
+
+        switch (depthClampMode)
+        {
+        case VK_DEPTH_CLAMP_MODE_VIEWPORT_RANGE_EXT:
+            PerGpuState(deviceIdx)->viewport.depthClampOverride.minDepth = 1.0f;
+            PerGpuState(deviceIdx)->viewport.depthClampOverride.maxDepth = 0.0f;
+            break;
+        case VK_DEPTH_CLAMP_MODE_USER_DEFINED_RANGE_EXT:
+            PerGpuState(deviceIdx)->viewport.depthClampOverride.minDepth = pDepthClampRange->minDepthClamp;
+            PerGpuState(deviceIdx)->viewport.depthClampOverride.maxDepth = pDepthClampRange->maxDepthClamp;
+            break;
+        default:
+            VK_ASSERT(!"Unexpected depthClampMode");
+            break;
+        }
     }
+    while (deviceGroup.IterateNext());
+
+    m_allGpuState.dirtyGraphics.viewport         = 1;
+    m_allGpuState.staticTokens.viewports = DynamicRenderStateToken;
 }
 
 // =====================================================================================================================
@@ -12577,15 +12587,6 @@ void CmdBuffer::ValidateGraphicsStates()
                     // Values more than 1.0f enable guardband.
                     viewportParams.horzDiscardRatio = 10.0f;
                     viewportParams.vertDiscardRatio = 10.0f;
-                }
-                if (m_allGpuState.depthClampOverride.minDepthClamp <= m_allGpuState.depthClampOverride.maxDepthClamp)
-                {
-                    for (uint32_t i = 0; i < viewportParams.count; ++i)
-                    {
-                        auto* const pViewport = &viewportParams.viewports[i];
-                        pViewport->minDepth = m_allGpuState.depthClampOverride.minDepthClamp;
-                        pViewport->maxDepth = m_allGpuState.depthClampOverride.maxDepthClamp;
-                    }
                 }
                 PalCmdBuffer(deviceIdx)->CmdSetViewports(viewportParams);
 

--- a/icd/api/vk_graphics_pipeline.cpp
+++ b/icd/api/vk_graphics_pipeline.cpp
@@ -1752,6 +1752,22 @@ void GraphicsPipeline::BindToCmdBuffer(
             } while (deviceGroup.IterateNext());
         }
 
+        if (ContainsStaticState(DynamicStatesInternal::DepthClampControl))
+        {
+            utils::IterateMask deviceGroup(pCmdBuffer->GetDeviceMask());
+            do
+            {
+                Pal::DepthClamp* pDepthClamp = &(pCmdBuffer->PerGpuState(deviceGroup.Index())->viewport.depthClampOverride);
+
+                if (pDepthClamp->minDepth != m_info.viewportParams.depthClampOverride.minDepth ||
+                    pDepthClamp->maxDepth != m_info.viewportParams.depthClampOverride.maxDepth)
+                {
+                    *pDepthClamp = m_info.viewportParams.depthClampOverride;
+                    pRenderState->dirtyGraphics.viewport = 1;
+                }
+            } while (deviceGroup.IterateNext());
+        }
+
         Pal::DepthRange depthRange = pGfxDynamicBindInfo->depthRange;
         if (ContainsStaticState(DynamicStatesInternal::DepthClipNegativeOneToOne))
         {
@@ -1769,11 +1785,6 @@ void GraphicsPipeline::BindToCmdBuffer(
 
             pRenderState->dirtyGraphics.viewport = 1;
         }
-    }
-
-    if (ContainsStaticState(DynamicStatesInternal::DepthClampControl))
-    {
-        pRenderState->depthClampOverride = m_info.depthClampOverride;
     }
 
     if (ContainsStaticState(DynamicStatesInternal::Scissor))


### PR DESCRIPTION
The current implementation does not respect the following line from the [extension description](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_depth_clamp_control.html#_description):

> It can be used to set a smaller or larger clamping range than the viewport depth range without affecting the depth mapping of the viewport transform.

Instead the driver currently implements this extension as a global override of the viewport depth range, which incorrectly does affect the viewport transform.

The implementation is also not consistent with the definition in the Vulkan specification section 30.10.1, which specifies that depth clamp control only overrides the `minDepth` and `maxDepth` of the viewport for the purposes of clamping the depth value.

To implement the extension correctly the registers for the viewport transform and the depth clamp need to be set separately. To achieve this the PR moves the `depthClampOverride` member from XGL to the `PAL::ViewportParams` struct in the Platform Abstraction Layer.

Additionally, the depth clamp override was previously treated as a global all-gpu parameter which seems to be incorrect for a device extension. Thus the new implementation now treats it as a per-gpu parameter.

Depends on the following PAL PR: https://github.com/GPUOpen-Drivers/pal/pull/110

I've also submitted an additional conformance test to cover this case: https://github.com/KhronosGroup/VK-GL-CTS/pull/532

Closes issue #182